### PR TITLE
fix(scripts): adds `publishedAt` to `push.getMessageHistory` payload

### DIFF
--- a/exampleExternalProviderScripts/pushExternalProviderScript.js
+++ b/exampleExternalProviderScripts/pushExternalProviderScript.js
@@ -47,6 +47,7 @@ this.web3inbox.push.on('getMessageHistory', ev => {
       1676830250101782: {
         id: 1676830250101782,
         topic: ev.topic,
+        publishedAt: 1676969627782,
         message: {
           title: 'Test Push 1',
           body: 'This is a test push notification',
@@ -57,6 +58,7 @@ this.web3inbox.push.on('getMessageHistory', ev => {
       1676830250192957: {
         id: 1676830250192957,
         topic: ev.topic,
+        publishedAt: 1676969637782,
         message: {
           title: 'Test Push 2',
           body: 'This is another test push notification',


### PR DESCRIPTION
## Context

- Aligning with https://docs.walletconnect.com/2.0/specs/clients/push/data-structures#push-message-record
- Support in `push-client` itself should land by EOD today/tomorrow, but no need to wait for it with these example payloads.