### PR TITLE
Stringify response

### DIFF
--- a/src/w3iProxy/chatProviders/androidChatProvider.ts
+++ b/src/w3iProxy/chatProviders/androidChatProvider.ts
@@ -18,7 +18,7 @@ export default class AndroidChatProvider extends ExternalChatProvider {
     ...params: Parameters<ChatClientFunctions[MName]>
   ) {
     return new Promise<ReturnType<ChatClientFunctions[MName]>>(resolve => {
-      const message = formatJsonRpcRequest(methodName, params)
+      const message = formatJsonRpcRequest(methodName, params[0])
 
       const messageListener = (
         messageResponse: JsonRpcResult<ReturnType<ChatClientFunctions[MName]>>

--- a/src/w3iProxy/chatProviders/iosChatProvider.ts
+++ b/src/w3iProxy/chatProviders/iosChatProvider.ts
@@ -22,7 +22,7 @@ export default class iOSChatProvider extends ExternalChatProvider {
     ...params: Parameters<ChatClientFunctions[MName]>
   ) {
     return new Promise<ReturnType<ChatClientFunctions[MName]>>(resolve => {
-      const message = formatJsonRpcRequest(methodName, params)
+      const message = formatJsonRpcRequest(methodName, params[0])
 
       const messageListener = (
         messageResponse: JsonRpcResult<ReturnType<ChatClientFunctions[MName]>>

--- a/src/w3iProxy/pushProviders/androidPushProvider.ts
+++ b/src/w3iProxy/pushProviders/androidPushProvider.ts
@@ -18,7 +18,7 @@ export default class AndroidPushProvider extends ExternalPushProvider {
     ...params: Parameters<PushClientFunctions[MName]>
   ) {
     return new Promise<ReturnType<PushClientFunctions[MName]>>(resolve => {
-      const message = formatJsonRpcRequest(methodName, params)
+      const message = formatJsonRpcRequest(methodName, params[0])
 
       const messageListener = (messageResponse: JsonRpcResult) => {
         resolve(messageResponse.result)

--- a/src/w3iProxy/pushProviders/iosPushProvider.ts
+++ b/src/w3iProxy/pushProviders/iosPushProvider.ts
@@ -22,7 +22,7 @@ export default class iOSPushProvider extends ExternalPushProvider {
     ...params: Parameters<PushClientFunctions[MName]>
   ) {
     return new Promise<ReturnType<PushClientFunctions[MName]>>(resolve => {
-      const message = formatJsonRpcRequest(methodName, params)
+      const message = formatJsonRpcRequest(methodName, params[0])
 
       const messageListener = (messageResponse: JsonRpcResult) => {
         resolve(messageResponse.result)


### PR DESCRIPTION
# Changes
- Stringify data posted to Kotlin, as parser expects to be string.
- Instead of sending a param array for both iOS and Kotlin, send the first param only. 