### PR TITLE
fix(css): set height for `.Main` to ensure height fill on mobile

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -35,6 +35,7 @@
     @include padding-x(0.4em);
     grid-area: main;
     max-width: 100vw;
+    height: 96vh;
 
     display: var(--main-display);
   }


### PR DESCRIPTION
- Helps with the mobile chat window issue shown in screenshot for now, but not a final solution to this.

<img width="633" alt="Screenshot 2023-03-01 at 06 49 05" src="https://user-images.githubusercontent.com/8663099/222201420-80441d4f-99df-4c9d-9c77-986c7b6f6ff1.png">
