### PR TITLE
fix(threads-height): removed height 100% to avoid pushing the empty box to the bottom

### DIFF
--- a/src/components/messages/ThreadSelector/ThreadSelector.scss
+++ b/src/components/messages/ThreadSelector/ThreadSelector.scss
@@ -115,7 +115,6 @@
     display: flex;
     flex-direction: column;
     gap: 1em;
-    height: 100%;
     width: 100%;
     justify-content: flex-start;
   }

--- a/src/components/messages/ThreadWindow/ThreadWindow.scss
+++ b/src/components/messages/ThreadWindow/ThreadWindow.scss
@@ -2,7 +2,7 @@
   display: flex;
   height: 100%;
   justify-content: space-between;
-  flex-flow: column wrap;
+  flex-direction: column;
 
   &__peer {
     color: var(--fg-color-1);


### PR DESCRIPTION
### Context

- Removed height 100% on threads classname to avoid pushing the next element down to the bottom
- Replaced `flex-flow: column wrap` with `flex-direction: column` to avoid issues on smaller devices (eg: iPhone SE)  