### PR TITLE
Fix/styling

### DIFF
--- a/src/components/messages/Message/Message.scss
+++ b/src/components/messages/Message/Message.scss
@@ -48,6 +48,9 @@
     padding: 0.4em 0.8em;
     will-change: border-radius;
     transition: border-radius ease 0.2s;
+    @media only screen and (max-width: 700px) {
+      max-width: 80%;
+    }
   }
 
   &__from-peer &__bubble {

--- a/src/components/messages/Message/Message.scss
+++ b/src/components/messages/Message/Message.scss
@@ -43,14 +43,13 @@
   }
 
   &__bubble {
-    max-width: 50%;
     overflow-wrap: break-word;
     padding: 0.4em 0.8em;
     will-change: border-radius;
     transition: border-radius ease 0.2s;
     max-width: 80%;
     @media only screen and (min-width: 700px) {
-        max-width: unset;
+      max-width: 50%;
     }
   }
 

--- a/src/components/messages/Message/Message.scss
+++ b/src/components/messages/Message/Message.scss
@@ -48,8 +48,9 @@
     padding: 0.4em 0.8em;
     will-change: border-radius;
     transition: border-radius ease 0.2s;
-    @media only screen and (max-width: 700px) {
-      max-width: 80%;
+    max-width: 80%;
+    @media only screen and (min-width: 700px) {
+        max-width: unset;
     }
   }
 

--- a/src/components/messages/MessageBox/MessageBox.scss
+++ b/src/components/messages/MessageBox/MessageBox.scss
@@ -10,6 +10,9 @@
   .Textarea {
     flex-grow: 1;
     border-radius: 16px 16px 6px 16px;
+    &:focus-within {
+      outline: 1px solid var(--accent-color-1);
+    }
   }
 
   &__send {

--- a/src/components/messages/NewChat/index.tsx
+++ b/src/components/messages/NewChat/index.tsx
@@ -119,7 +119,7 @@ const NewChat: React.FC = () => {
             <div className="NewChat__input-container">
               <Input
                 value={query}
-                placeholder="ENS Username (vitalik.eth)⠀ ⠀ ⠀Wallet Address (0x423…)"
+                placeholder="ENS Username (vitalik.eth) / Wallet Address (0x423…)"
                 onChange={e => setQuery(e.target.value)}
               />
             </div>
@@ -128,7 +128,7 @@ const NewChat: React.FC = () => {
           <div className="NewChat__search-box">
             <Input
               value={query}
-              placeholder="ENS Username (vitalik.eth)⠀ ⠀ ⠀Wallet Address (0x423…)"
+              placeholder="ENS Username (vitalik.eth) / Wallet Address (0x423…)"
               onChange={e => setQuery(e.target.value)}
             />
             <Button

--- a/src/components/messages/ThreadSelector/ThreadSelector.scss
+++ b/src/components/messages/ThreadSelector/ThreadSelector.scss
@@ -56,6 +56,7 @@
 
   &__link {
     display: flex;
+    gap: 0.5em;
 
     @media only screen and (max-width: 700px) {
       background: var(--accent-color-1);
@@ -74,8 +75,8 @@
         background: var(--accent-color-1);
         border-radius: 50%;
         padding: 0.5em;
-        width: 2.25em;
-        height: 2.25em;
+        width: 1.75em;
+        height: 1.75em;
       }
     }
   }

--- a/src/components/messages/ThreadSelector/ThreadSelector.scss
+++ b/src/components/messages/ThreadSelector/ThreadSelector.scss
@@ -6,7 +6,8 @@
   height: 100%;
   align-items: center;
   gap: 1em;
-  min-width: 17.5em;
+  max-width: 17.5em;
+  min-width: 16em;
 
   @media only screen and (max-width: 700px) {
     padding: 0 1.25em 1.25em 1.25em;


### PR DESCRIPTION
## Title

Several Styling fixes as per #59 

## Examples

### new chat icon too large
<img width="396" alt="image" src="https://user-images.githubusercontent.com/26746725/225302628-f264734b-05da-4e4d-86bb-0966cb80a892.png">

### change placeholder in new chat space to slash
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/26746725/225302723-f0463521-060e-46ce-b812-437d1d0d83b9.png">

### MessageBox focus state (blue border)
<img width="1018" alt="image" src="https://user-images.githubusercontent.com/26746725/225302824-d90f43fc-2b10-4260-bfe2-a2ae2ec6de67.png">

### Max width for the thread selector: 280px
(Changed in code, also modified `min-width` which should probably be adjusted later)

### Max message width in mobile should be 80%
<img width="674" alt="image" src="https://user-images.githubusercontent.com/26746725/225302958-ed8eab26-6a02-43e7-bbda-bf53eb52699b.png">
