### PR TITLE
Add authenticated redirection

### DIFF
--- a/src/components/account/Avatar/index.tsx
+++ b/src/components/account/Avatar/index.tsx
@@ -98,7 +98,12 @@ const Avatar: React.FC<AvatarProps> = ({ address, width, height, hasProfileDropd
               >
                 {ensAvatar && <img className="Avatar__icon" src={ensAvatar} alt="Avatar" />}
               </div>
-              <div className="Avatar__dropdown__block__username">
+              <div
+                className="Avatar__dropdown__block__username"
+                onClick={() => {
+                  window.navigator.clipboard.writeText(address ?? '')
+                }}
+              >
                 {ensName ?? truncate(address ?? '', 4)}
               </div>
             </div>

--- a/src/components/general/Spinner/index.tsx
+++ b/src/components/general/Spinner/index.tsx
@@ -10,7 +10,7 @@ const Spinner: React.FC<SpinnerProps> = ({ width }) => {
   return (
     <div className="Spinner" style={{ width, height: width }}>
       <div className="Spinner__inner">
-        <img src={SpinnerImage} alt="Spinner" />
+        <img src={SpinnerImage} style={{ width, height: width }} alt="Spinner" />
       </div>
     </div>
   )

--- a/src/components/messages/ThreadSelector/Thread/index.tsx
+++ b/src/components/messages/ThreadSelector/Thread/index.tsx
@@ -35,7 +35,7 @@ const Thread: React.FC<ThreadProps> = ({
   }, [chatClientProxy, calculatedLastMessage, lastMessage, setCalculatedLastMessage])
 
   return (
-    <NavLink to={`/messages/chat/${threadPeer}`}>
+    <NavLink to={`/messages/chat/${threadPeer}?topic=${topic}`}>
       <PeerAndMessage
         highlightedText={searchQuery}
         peer={threadPeer}

--- a/src/components/messages/ThreadSelector/Thread/index.tsx
+++ b/src/components/messages/ThreadSelector/Thread/index.tsx
@@ -35,7 +35,7 @@ const Thread: React.FC<ThreadProps> = ({
   }, [chatClientProxy, calculatedLastMessage, lastMessage, setCalculatedLastMessage])
 
   return (
-    <NavLink to={`/messages/chat/${threadPeer}?topic=${topic}`}>
+    <NavLink to={`/messages/chat/${threadPeer}`}>
       <PeerAndMessage
         highlightedText={searchQuery}
         peer={threadPeer}

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -19,11 +19,13 @@ const ThreadWindow: React.FC = () => {
   const { peer } = useParams<{ peer: string }>()
   const peerAddress = (peer?.split(':')[2] ?? `0x`) as `0x${string}`
   const { search } = useLocation()
-
-  const topic = new URLSearchParams(search).get('topic') ?? ''
-  console.log(`Pulling a topic from search query: ${search}, result: ${topic}`)
   const { data: ensName } = useEnsName({ address: peerAddress })
   const { chatClientProxy, userPubkey, threads, sentInvites } = useContext(W3iContext)
+
+  const topic = threads.find(thread => thread.peerAccount === peer)?.topic ?? ''
+
+  console.log(`Using topic ${topic}`)
+
   const nav = useNavigate()
 
   const [messages, setMessages] = useState<ChatClientTypes.Message[]>([])

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -1,6 +1,6 @@
 import type { ChatClientTypes } from '@walletconnect/chat-client'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Navigate, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useEnsName } from 'wagmi'
 import W3iContext from '../../../contexts/W3iContext/context'
 import { truncate } from '../../../utils/string'
@@ -22,7 +22,14 @@ const ThreadWindow: React.FC = () => {
   const { data: ensName } = useEnsName({ address: peerAddress })
   const { chatClientProxy, userPubkey, threads, sentInvites } = useContext(W3iContext)
 
-  const topic = threads.find(thread => thread.peerAccount === peer)?.topic ?? ''
+  const topic =
+    new URLSearchParams(search).get('topic') ??
+    threads.find(thread => thread.peerAccount === peer)?.topic ??
+    ''
+
+  if (!topic) {
+    return <Navigate to="/messages" />
+  }
 
   const nav = useNavigate()
 

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -18,8 +18,10 @@ import ThreadDropdown from './ThreadDropdown'
 const ThreadWindow: React.FC = () => {
   const { peer } = useParams<{ peer: string }>()
   const peerAddress = (peer?.split(':')[2] ?? `0x`) as `0x${string}`
-  const [topic, setTopic] = useState('')
   const { search } = useLocation()
+
+  const topic = new URLSearchParams(search).get('topic') ?? ''
+  console.log(`Pulling a topic from search query: ${search}, result: ${topic}`)
   const { data: ensName } = useEnsName({ address: peerAddress })
   const { chatClientProxy, userPubkey, threads, sentInvites } = useContext(W3iContext)
   const nav = useNavigate()
@@ -37,10 +39,6 @@ const ThreadWindow: React.FC = () => {
         : 'approved',
     [topic]
   )
-
-  useEffect(() => {
-    setTopic(new URLSearchParams(search).get('topic') ?? '')
-  }, [search])
 
   const refreshMessages = useCallback(() => {
     console.log(

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -110,6 +110,11 @@ const ThreadWindow: React.FC = () => {
     const inviteAcceptedSub = chatClientProxy.observe('chat_invite_accepted', {
       next: inviteAcceptedEvent => {
         const { inviteeAccount } = inviteAcceptedEvent.params.invite
+        console.log(
+          `Accepted invite event, isInvite: ${isInvite ? 'YES' : 'NO'}, inviteeAccount: ${
+            inviteAcceptedEvent.params.invite.inviteeAccount
+          }`
+        )
         if (isInvite && inviteAcceptedEvent.params.invite.inviteeAccount === peer) {
           nav(`/messages/chat/${inviteeAccount}?topic=${inviteAcceptedEvent.params.topic}`)
         }

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -43,6 +43,12 @@ const ThreadWindow: React.FC = () => {
   }, [search])
 
   const refreshMessages = useCallback(() => {
+    console.log(
+      `Calling refreshMessages with topic ${topic} and a ${
+        chatClientProxy ? 'truthy' : 'falsy'
+      } client`
+    )
+
     if (!chatClientProxy || !topic) {
       return
     }
@@ -123,6 +129,7 @@ const ThreadWindow: React.FC = () => {
   }, [chatClientProxy, refreshMessages, topic, nav, peer])
 
   useEffect(() => {
+    console.log('Refresh messages useEffect')
     refreshMessages()
   }, [refreshMessages])
 

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -58,6 +58,15 @@ const ThreadWindow: React.FC = () => {
         console.error('getMessages failed, redirecting to root')
         nav('/')
       })
+
+    if (!topic.includes('invite')) {
+      chatClientProxy.getThreads().then(retreivedThreads => {
+        if (!retreivedThreads.get(topic)) {
+          console.error('topic not in threads, redirecting to root')
+          nav('/')
+        }
+      })
+    }
   }, [chatClientProxy, search, setMessages, topic])
 
   useEffect(() => {
@@ -112,11 +121,6 @@ const ThreadWindow: React.FC = () => {
   useEffect(() => {
     refreshMessages()
   }, [refreshMessages, chatClientProxy])
-
-  if (!(threads.map(thread => thread.topic).includes(topic) || topic.includes('invite'))) {
-    console.error('topic not in threads, redirecting to root')
-    nav('/')
-  }
 
   return (
     <div className="ThreadWindow">

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -24,8 +24,6 @@ const ThreadWindow: React.FC = () => {
 
   const topic = threads.find(thread => thread.peerAccount === peer)?.topic ?? ''
 
-  console.log(`Using topic ${topic}`)
-
   const nav = useNavigate()
 
   const [messages, setMessages] = useState<ChatClientTypes.Message[]>([])

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -54,7 +54,10 @@ const ThreadWindow: React.FC = () => {
       .then(allChatMessages => {
         setMessages(allChatMessages)
       })
-      .catch(() => nav('/'))
+      .catch(() => {
+        console.error('getMessages failed, redirecting to root')
+        nav('/')
+      })
   }, [chatClientProxy, search, setMessages, topic])
 
   useEffect(() => {
@@ -111,6 +114,7 @@ const ThreadWindow: React.FC = () => {
   }, [refreshMessages, chatClientProxy])
 
   if (!(threads.map(thread => thread.topic).includes(topic) || topic.includes('invite'))) {
+    console.error('topic not in threads, redirecting to root')
     nav('/')
   }
 

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -109,13 +109,13 @@ const ThreadWindow: React.FC = () => {
 
     const inviteAcceptedSub = chatClientProxy.observe('chat_invite_accepted', {
       next: inviteAcceptedEvent => {
-        const { inviteeAccount } = inviteAcceptedEvent.params.invite
         console.log(
-          `Accepted invite event, isInvite: ${isInvite ? 'YES' : 'NO'}, inviteeAccount: ${
-            inviteAcceptedEvent.params.invite.inviteeAccount
-          }`
+          `Accepted invite event, isInvite: ${
+            isInvite ? 'YES' : 'NO'
+          }, inviteeAccount: ${JSON.stringify(inviteAcceptedEvent)}`
         )
-        if (isInvite && inviteAcceptedEvent.params.invite.inviteeAccount === peer) {
+        const { inviteeAccount } = inviteAcceptedEvent.params.invite
+        if (isInvite && inviteeAccount === peer) {
           nav(`/messages/chat/${inviteeAccount}?topic=${inviteAcceptedEvent.params.topic}`)
         }
       }

--- a/src/components/messages/ThreadWindow/index.tsx
+++ b/src/components/messages/ThreadWindow/index.tsx
@@ -47,11 +47,14 @@ const ThreadWindow: React.FC = () => {
       return
     }
 
+    console.log(`Retreiving messages for topic ${topic}`)
+
     chatClientProxy
       .getMessages({
         topic
       })
       .then(allChatMessages => {
+        console.log(`Retreived messages: ${allChatMessages.map(m => m.timestamp).join(',')} `)
         setMessages(allChatMessages)
       })
       .catch(() => {
@@ -59,8 +62,9 @@ const ThreadWindow: React.FC = () => {
         nav('/')
       })
 
-    if (!topic.includes('invite')) {
-      chatClientProxy.getThreads().then(retreivedThreads => {
+    if (!topic.includes('invite') && userPubkey) {
+      // Not using `threads` to avoid a data race.
+      chatClientProxy.getThreads({ account: `eip155:1:${userPubkey}` }).then(retreivedThreads => {
         if (!retreivedThreads.get(topic)) {
           console.error('topic not in threads, redirecting to root')
           nav('/')
@@ -120,7 +124,7 @@ const ThreadWindow: React.FC = () => {
 
   useEffect(() => {
     refreshMessages()
-  }, [refreshMessages, chatClientProxy])
+  }, [refreshMessages])
 
   return (
     <div className="ThreadWindow">

--- a/src/components/utils/AuthProtectedPage.tsx
+++ b/src/components/utils/AuthProtectedPage.tsx
@@ -9,7 +9,7 @@ interface AuthProtectedPageProps {
 const AuthProtectedPage: React.FC<AuthProtectedPageProps> = ({ children }) => {
   const { userPubkey } = useContext(W3iContext)
   const loc = useLocation()
-  const next = loc.pathname
+  const next = `${loc.pathname}${loc.search}`
 
   if (!userPubkey) {
     const query = next.length > 1 ? `?next=${encodeURIComponent(next)}` : ''

--- a/src/components/utils/AuthProtectedPage.tsx
+++ b/src/components/utils/AuthProtectedPage.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment, useContext } from 'react'
-import { Navigate } from 'react-router-dom'
+import { Navigate, useLocation } from 'react-router-dom'
 import W3iContext from '../../contexts/W3iContext/context'
 
 interface AuthProtectedPageProps {
@@ -8,9 +8,13 @@ interface AuthProtectedPageProps {
 
 const AuthProtectedPage: React.FC<AuthProtectedPageProps> = ({ children }) => {
   const { userPubkey } = useContext(W3iContext)
+  const loc = useLocation()
+  const next = loc.pathname
 
   if (!userPubkey) {
-    return <Navigate to={'/login'} />
+    const query = next.length > 1 ? `?next=${next}` : ''
+
+    return <Navigate to={`/login${query}`} />
   }
 
   return <Fragment>{children}</Fragment>

--- a/src/components/utils/AuthProtectedPage.tsx
+++ b/src/components/utils/AuthProtectedPage.tsx
@@ -12,7 +12,7 @@ const AuthProtectedPage: React.FC<AuthProtectedPageProps> = ({ children }) => {
   const next = loc.pathname
 
   if (!userPubkey) {
-    const query = next.length > 1 ? `?next=${next}` : ''
+    const query = next.length > 1 ? `?next=${encodeURIComponent(next)}` : ''
 
     return <Navigate to={`/login${query}`} />
   }

--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -16,6 +16,8 @@ interface W3iContextState {
   userPubkey?: string
   pushClientProxy: W3iPushClient | null
   registerMessage: string | null
+  chatProvider: string
+  pushProvider: string
 }
 
 const W3iContext = createContext<W3iContextState>({
@@ -30,7 +32,9 @@ const W3iContext = createContext<W3iContextState>({
   sentInvites: [],
   invites: [],
   pushClientProxy: null,
-  registerMessage: null
+  registerMessage: null,
+  chatProvider: '',
+  pushProvider: ''
 })
 
 export default W3iContext

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -168,6 +168,8 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     <W3iContext.Provider
       value={{
         chatClientProxy: chatClient,
+        chatProvider,
+        pushProvider,
         userPubkey,
         refreshThreadsAndInvites: refreshChatState,
         sentInvites,

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,6 +1,6 @@
 import { Web3Button } from '@web3modal/react'
 import React, { useContext, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import ByWalletConnect from '../../assets/by_walletconnect.png'
 import ChatDisplay from '../../assets/chat.png'
 import Logo from '../../assets/Logo.svg'
@@ -8,6 +8,7 @@ import NotificationDisplay from '../../assets/notifs.png'
 import Web3InboxDisplay from '../../assets/web3inbox.png'
 import MessageIcon from '../../components/general/Icon/MessageIcon'
 import NotificationIcon from '../../components/general/Icon/NotificationIcon'
+import Spinner from '../../components/general/Spinner'
 import W3iContext from '../../contexts/W3iContext/context'
 import { signatureModalService } from '../../utils/store'
 import './Login.scss'
@@ -29,21 +30,29 @@ const Web3InboxFeatures = [
 ]
 
 const Login: React.FC = () => {
-  const { userPubkey, registeredKey, registerMessage } = useContext(W3iContext)
+  const { userPubkey, chatProvider, registeredKey, registerMessage } = useContext(W3iContext)
+  const { search } = useLocation()
+  const next = new URLSearchParams(search).get('next')
   const nav = useNavigate()
 
   useEffect(() => {
-    if (!userPubkey) {
-      nav('/login')
-    }
     if (userPubkey && registeredKey) {
-      nav('/')
+      const path = next ? next : '/'
+      nav(path)
     }
 
     if (userPubkey && !registeredKey && registerMessage) {
       signatureModalService.openModal()
     }
-  }, [userPubkey, registeredKey, registerMessage])
+  }, [userPubkey, next, registeredKey, registerMessage])
+
+  if (chatProvider !== 'internal') {
+    return (
+      <div className="Login">
+        <Spinner width="3em" />
+      </div>
+    )
+  }
 
   return (
     <div className="Login">

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -37,7 +37,7 @@ const Login: React.FC = () => {
 
   useEffect(() => {
     if (userPubkey && registeredKey) {
-      const path = next ?? '/'
+      const path = next ? decodeURIComponent(next) : '/'
       nav(path)
     }
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -37,7 +37,7 @@ const Login: React.FC = () => {
 
   useEffect(() => {
     if (userPubkey && registeredKey) {
-      const path = next ? next : '/'
+      const path = next ?? '/'
       nav(path)
     }
 


### PR DESCRIPTION
# Changes
- Login page becomes a spinner when `chatProvider !== "internal"`
- Login page now redirects to intended page when authenticated. Eg going to `/notifications` when authenticated will actually go to `/notifications` instead of `/messages`