### PR TITLE
Add React Native communicator

### DIFF
--- a/src/w3iProxy/chatProviders/externalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/externalChatProvider.ts
@@ -6,6 +6,7 @@ import type { ExternalCommunicator } from '../externalCommunicators/communicator
 import { AndroidCommunicator } from '../externalCommunicators/androidCommunicator'
 import { IOSCommunicator } from '../externalCommunicators/iosCommunicator'
 import { JsCommunicator } from '../externalCommunicators/jsCommunicator'
+import { ReactNativeCommunicator } from '../externalCommunicators/reactNativeCommunicator'
 
 export default class ExternalChatProvider implements W3iChatProvider {
   protected readonly emitter: EventEmitter
@@ -34,6 +35,9 @@ export default class ExternalChatProvider implements W3iChatProvider {
         break
       case 'ios':
         this.communicator = new IOSCommunicator(this.emitter)
+        break
+      case 'reactnative':
+        this.communicator = new ReactNativeCommunicator(this.emitter)
         break
       default:
         this.communicator = new JsCommunicator(this.emitter)

--- a/src/w3iProxy/externalCommunicators/reactNativeCommunicator.ts
+++ b/src/w3iProxy/externalCommunicators/reactNativeCommunicator.ts
@@ -1,0 +1,34 @@
+import type { ExternalCommunicator } from './communicatorType'
+import type { EventEmitter } from 'events'
+import type { JsonRpcResult } from '@walletconnect/jsonrpc-utils'
+import { formatJsonRpcRequest } from '@walletconnect/jsonrpc-utils'
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: {
+      postMessage: (message: unknown) => void
+    }
+  }
+}
+
+export class ReactNativeCommunicator implements ExternalCommunicator {
+  private readonly emitter: EventEmitter
+
+  public constructor(emitter: EventEmitter) {
+    this.emitter = emitter
+  }
+
+  public async postToExternalProvider<TReturn>(methodName: string, params: unknown) {
+    return new Promise<TReturn>(resolve => {
+      const message = formatJsonRpcRequest(methodName, params)
+
+      const messageListener = (messageResponse: JsonRpcResult<TReturn>) => {
+        resolve(messageResponse.result)
+      }
+      this.emitter.once(message.id.toString(), messageListener)
+      if (window.ReactNativeWebView) {
+        window.ReactNativeWebView.postMessage(JSON.stringify(message))
+      }
+    })
+  }
+}

--- a/src/w3iProxy/pushProviders/externalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/externalPushProvider.ts
@@ -5,6 +5,7 @@ import type { ExternalCommunicator } from '../externalCommunicators/communicator
 import { AndroidCommunicator } from '../externalCommunicators/androidCommunicator'
 import { IOSCommunicator } from '../externalCommunicators/iosCommunicator'
 import { JsCommunicator } from '../externalCommunicators/jsCommunicator'
+import { ReactNativeCommunicator } from '../externalCommunicators/reactNativeCommunicator'
 
 export default class ExternalPushProvider implements W3iPushProvider {
   protected readonly emitter: EventEmitter
@@ -24,6 +25,9 @@ export default class ExternalPushProvider implements W3iPushProvider {
         break
       case 'ios':
         this.communicator = new IOSCommunicator(this.emitter)
+        break
+      case 'reactnative':
+        this.communicator = new ReactNativeCommunicator(this.emitter)
         break
       default:
         this.communicator = new JsCommunicator(this.emitter)

--- a/src/w3iProxy/w3iChatFacade.ts
+++ b/src/w3iProxy/w3iChatFacade.ts
@@ -28,6 +28,7 @@ class W3iChatFacade implements W3iChat {
     internal: InternalChatProvider,
     external: ExternalChatProvider,
     ios: ExternalChatProvider,
+    reactnative: ExternalChatProvider,
     android: ExternalChatProvider
   }
   private readonly providerName: keyof typeof this.providerMap

--- a/src/w3iProxy/w3iPushFacade.ts
+++ b/src/w3iProxy/w3iPushFacade.ts
@@ -17,6 +17,7 @@ class W3iPushFacade implements W3iPush {
     internal: InternalPushProvider,
     external: ExternalPushProvider,
     android: ExternalPushProvider,
+    reactnative: ExternalPushProvider,
     ios: ExternalPushProvider
   }
   private readonly providerName: keyof typeof this.providerMap


### PR DESCRIPTION
# Changes
- Add `ReactNativeCommunicator` to communicate with react native webviews
- It is accessed through `chatProvider=reactnative` and of course `pushProvider=reactnative`
- Adapted `ExternalProvider` to use the new communicator when requested