### PR TITLE
feat: expose `pushWalletClient.subscribe` for external providers

### DIFF
--- a/src/w3iProxy/pushProviders/externalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/externalPushProvider.ts
@@ -67,12 +67,12 @@ export default class ExternalPushProvider implements W3iPushProvider {
     return this.postToExternalProvider('reject', params)
   }
 
-  public async subscribe(params: {
-    metadata: PushClientTypes.Metadata
-    account: string
-    onSign: (message: string) => string
-  }) {
-    return this.postToExternalProvider('subscribe', params)
+  public async subscribe(params: { metadata: PushClientTypes.Metadata; account: string }) {
+    return this.postToExternalProvider('subscribe', {
+      ...params,
+      // Signing will be handled wallet-side.
+      onSign: async () => Promise.resolve('')
+    })
   }
 
   public async deleteSubscription(params: { topic: string }) {

--- a/src/w3iProxy/pushProviders/externalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/externalPushProvider.ts
@@ -1,5 +1,6 @@
 import type { EventEmitter } from 'events'
 import type { JsonRpcRequest } from '@walletconnect/jsonrpc-utils'
+import type { PushClientTypes } from '@walletconnect/push-client'
 import type { PushClientFunctions, W3iPushProvider } from './types'
 import type { ExternalCommunicator } from '../externalCommunicators/communicatorType'
 import { AndroidCommunicator } from '../externalCommunicators/androidCommunicator'
@@ -64,6 +65,14 @@ export default class ExternalPushProvider implements W3iPushProvider {
 
   public async reject(params: { id: number; reason: string }) {
     return this.postToExternalProvider('reject', params)
+  }
+
+  public async subscribe(params: {
+    metadata: PushClientTypes.Metadata
+    account: string
+    onSign: (message: string) => string
+  }) {
+    return this.postToExternalProvider('subscribe', params)
   }
 
   public async deleteSubscription(params: { topic: string }) {

--- a/src/w3iProxy/pushProviders/internalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/internalPushProvider.ts
@@ -1,6 +1,6 @@
 import type { EventEmitter } from 'events'
 import type { W3iPushProvider } from './types'
-import type { WalletClient as PushWalletClient } from '@walletconnect/push-client'
+import type { PushClientTypes, WalletClient as PushWalletClient } from '@walletconnect/push-client'
 import { appNotificationsMock, myAppsMock } from '../../utils/mocks'
 
 export default class InternalPushProvider implements W3iPushProvider {
@@ -53,6 +53,19 @@ export default class InternalPushProvider implements W3iPushProvider {
     }
 
     return this.pushClient.reject(params)
+  }
+
+  public async subscribe(_params: {
+    metadata: PushClientTypes.Metadata
+    account: string
+    onSign: (message: string) => string
+  }) {
+    if (!this.pushClient) {
+      throw new Error(this.formatClientRelatedError('subscribe'))
+    }
+
+    // Noop until we have a real push client implementation ready.
+    return Promise.resolve(false)
   }
 
   public async deleteSubscription(params: { topic: string }) {

--- a/src/w3iProxy/pushProviders/internalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/internalPushProvider.ts
@@ -55,11 +55,7 @@ export default class InternalPushProvider implements W3iPushProvider {
     return this.pushClient.reject(params)
   }
 
-  public async subscribe(_params: {
-    metadata: PushClientTypes.Metadata
-    account: string
-    onSign: (message: string) => string
-  }) {
+  public async subscribe(_params: { metadata: PushClientTypes.Metadata; account: string }) {
     if (!this.pushClient) {
       throw new Error(this.formatClientRelatedError('subscribe'))
     }

--- a/src/w3iProxy/pushProviders/internalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/internalPushProvider.ts
@@ -60,7 +60,9 @@ export default class InternalPushProvider implements W3iPushProvider {
       throw new Error(this.formatClientRelatedError('subscribe'))
     }
 
-    // Noop until we have a real push client implementation ready.
+    /**
+     * TODO: Noop until we have a real push client implementation ready.
+     */
     return Promise.resolve(false)
   }
 

--- a/src/w3iProxy/pushProviders/types.ts
+++ b/src/w3iProxy/pushProviders/types.ts
@@ -49,7 +49,7 @@ type PushWalletClientWithSubscribe = PushWalletClient & {
   subscribe: (params: {
     metadata: PushClientTypes.Metadata
     account: string
-    onSign: (message: string) => string
+    onSign: (message: string) => Promise<string>
   }) => Promise<boolean>
 }
 

--- a/src/w3iProxy/pushProviders/types.ts
+++ b/src/w3iProxy/pushProviders/types.ts
@@ -1,5 +1,5 @@
 import type { JsonRpcRequest } from '@walletconnect/jsonrpc-utils'
-import type { WalletClient as PushWalletClient } from '@walletconnect/push-client'
+import type { WalletClient as PushWalletClient, PushClientTypes } from '@walletconnect/push-client'
 import type { NextObserver, Observable } from 'rxjs'
 import type { PushFacadeEvents } from '../listenerTypes'
 
@@ -41,6 +41,18 @@ interface ModifiedPushClientFunctions {
   ) => Promise<ReturnType<PushWalletClient['getMessageHistory']>>
 }
 
+/*
+ * Monkey-patching in `walletClient.subscribe()` until JS Push has implemented.
+ * TODO: Remove this when JS Push has implemented `walletClient.subscribe()`
+ */
+type PushWalletClientWithSubscribe = PushWalletClient & {
+  subscribe: (params: {
+    metadata: PushClientTypes.Metadata
+    account: string
+    onSign: (message: string) => string
+  }) => Promise<boolean>
+}
+
 export type PushObservableMap = Map<
   keyof PushFacadeEvents,
   Observable<PushFacadeEvents[keyof PushFacadeEvents]>
@@ -49,7 +61,7 @@ export type PushObservableMap = Map<
 export type PushEventObserver<K extends keyof PushFacadeEvents> = NextObserver<PushFacadeEvents[K]>
 export type PushEventObservable<K extends keyof PushFacadeEvents> = Observable<PushFacadeEvents[K]>
 
-export type PushClientFunctions = Omit<PushWalletClient, NonMethodPushClientKeys>
+export type PushClientFunctions = Omit<PushWalletClientWithSubscribe, NonMethodPushClientKeys>
 export type W3iPush = ModifiedPushClientFunctions &
   Omit<PushClientFunctions, keyof ModifiedPushClientFunctions>
 

--- a/src/w3iProxy/w3iPushFacade.ts
+++ b/src/w3iProxy/w3iPushFacade.ts
@@ -59,11 +59,7 @@ class W3iPushFacade implements W3iPush {
     return this.provider.reject(params)
   }
 
-  public async subscribe(params: {
-    metadata: PushClientTypes.Metadata
-    account: string
-    onSign: (message: string) => string
-  }) {
+  public async subscribe(params: { metadata: PushClientTypes.Metadata; account: string }) {
     return this.provider.subscribe(params)
   }
 

--- a/src/w3iProxy/w3iPushFacade.ts
+++ b/src/w3iProxy/w3iPushFacade.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import type { JsonRpcRequest } from '@walletconnect/jsonrpc-utils'
 import { fromEvent } from 'rxjs'
-import type { WalletClient as PushWalletClient } from '@walletconnect/push-client'
+import type { PushClientTypes, WalletClient as PushWalletClient } from '@walletconnect/push-client'
 import type {
   PushEventObservable,
   PushEventObserver,
@@ -57,6 +57,14 @@ class W3iPushFacade implements W3iPush {
 
   public async reject(params: { id: number; reason: string }) {
     return this.provider.reject(params)
+  }
+
+  public async subscribe(params: {
+    metadata: PushClientTypes.Metadata
+    account: string
+    onSign: (message: string) => string
+  }) {
+    return this.provider.subscribe(params)
   }
 
   public async deleteSubscription(params: { topic: string }) {


### PR DESCRIPTION
# Description

- As discussed with @Cali93 @devceline @llbartekll 
- Expose `PushWalletClient.subscribe` method for externalProvider demo purposes
- InternalProvider usage is a no-op until JS Push has `wc_pushSubscribe` implemented.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
