### PR TITLE
Update signature modal to allow for cancel

### DIFF
--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -15,6 +15,7 @@ interface W3iContextState {
   threads: ChatClientTypes.Thread[]
   invites: ChatClientTypes.ReceivedInvite[]
   userPubkey?: string
+  disconnect: () => void
   pushClientProxy: W3iPushClient | null
   registerMessage: string | null
   chatProvider: string
@@ -26,6 +27,8 @@ const W3iContext = createContext<W3iContextState>({
   registeredKey: null,
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   refreshThreadsAndInvites: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  disconnect: () => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setUserPubkey: () => {},
   threads: [],

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -7,6 +7,7 @@ import type { ChatClientTypes } from '@walletconnect/chat-client'
 import { noop } from 'rxjs'
 import type { PushClientTypes } from '@walletconnect/push-client'
 import { useLocation } from 'react-router-dom'
+import { useDisconnect } from 'wagmi'
 
 interface W3iContextProviderProps {
   children: React.ReactNode | React.ReactNode[]
@@ -14,6 +15,7 @@ interface W3iContextProviderProps {
 
 const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => {
   const [registerMessage, setRegisterMessage] = useState<string | null>(null)
+  const { disconnect: wagmiDisconnect } = useDisconnect()
   const relayUrl = import.meta.env.VITE_RELAY_URL
   const projectId = import.meta.env.VITE_PROJECT_ID
   const query = new URLSearchParams(window.location.search)
@@ -42,6 +44,12 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     pushProviderQuery ? (pushProviderQuery as Web3InboxProxy['pushProvider']) : 'internal'
   )
 
+  const disconnect = useCallback(() => {
+    setUserPubkey(undefined)
+    setRegistered(null)
+    wagmiDisconnect()
+  }, [wagmiDisconnect])
+
   useEffect(() => {
     const account = new URLSearchParams(search).get('account')
 
@@ -61,6 +69,7 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
 
     return () => sub?.unsubscribe()
   }, [chatClient])
+
   useEffect(() => {
     if (chatClient && pushClient) {
       return
@@ -181,6 +190,7 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
         threads,
         activeSubscriptions,
         invites,
+        disconnect,
         registeredKey,
         setUserPubkey,
         registerMessage,

--- a/src/pages/Login/SignatureModal/SignatureModal.scss
+++ b/src/pages/Login/SignatureModal/SignatureModal.scss
@@ -1,14 +1,29 @@
 @import '../../../styles/mixins.scss';
 
 .SignatureModal {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 1em;
   padding: 1.25em;
 
+  &__cancel-container {
+    width: 100%;
+    position: absolute;
+    top: 1em;
+    right: 1em;
+    justify-content: flex-end;
+    display: flex;
+
+    & button {
+      width: 10% !important;
+    }
+  }
+
   &__header {
     display: flex;
+    padding-top: 1em;
     flex-direction: column;
     align-items: center;
     gap: 0.5em;

--- a/src/pages/Login/SignatureModal/index.tsx
+++ b/src/pages/Login/SignatureModal/index.tsx
@@ -1,5 +1,5 @@
 import { signMessage } from '@wagmi/core'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 import Button from '../../../components/general/Button'
 import { Modal } from '../../../components/general/Modal/Modal'
 import { signatureModalService } from '../../../utils/store'
@@ -7,10 +7,17 @@ import { formatJsonRpcRequest } from '@walletconnect/jsonrpc-utils'
 import './SignatureModal.scss'
 import CheckIcon from '../../../components/general/Icon/CheckIcon'
 import Spinner from '../../../components/general/Spinner'
+import CrossIcon from '../../../components/general/Icon/CrossIcon'
+import W3iContext from '../../../contexts/W3iContext/context'
 
 export const SignatureModal: React.FC<{ message: string }> = ({ message }) => {
+  const { disconnect } = useContext(W3iContext)
   const purpose: 'identity' | 'sync' = message.includes('did:key') ? 'identity' : 'sync'
-  const [stepProgress, setStepProgress] = useState(0)
+  /*
+   * If identity was already signed, and sync was requested then we are in the
+   * final step.
+   */
+  const [stepProgress, setStepProgress] = useState(purpose === 'identity' ? 0 : 1)
   const [signing, setSigning] = useState(false)
 
   const steps = [
@@ -41,6 +48,11 @@ export const SignatureModal: React.FC<{ message: string }> = ({ message }) => {
   return (
     <Modal onToggleModal={signatureModalService.toggleModal}>
       <div className="SignatureModal">
+        <div className="SignatureModal__cancel-container">
+          <Button onClick={disconnect} customType="danger">
+            <CrossIcon />
+          </Button>
+        </div>
         <div className="SignatureModal__header">
           <div className="SignatureModal__progress">
             <div className="SignatureModal__progress-bubbles">


### PR DESCRIPTION
# Description

Allow to cancel out of signature modal. 

Also, it remembers your progress so if one person signed an identity key, canceled out of modal and then tried to connect their account again, they'd only have to register their sync key.

# Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Examples/Screenshots 

| Before       | After        |
| ------------ | ------------ |
| ![image](https://user-images.githubusercontent.com/61278030/234324483-5cddac14-45b1-413b-94e7-a87ae745da59.png) | ![image](https://user-images.githubusercontent.com/61278030/234324208-710f2573-e4f1-4e86-8da9-dd9799df9721.png) |


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

