### PR TITLE
Allow for managing what UIs are available

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,7 @@
   "extends": ["eslint:all", "plugin:@typescript-eslint/all", "prettier"],
   "rules": {
     "sort-imports": "off",
-		"no-duplicate-imports": "off",
+    "no-duplicate-imports": "off",
     "no-console": "off",
     "one-var": "off",
     "sort-keys": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
   "extends": ["eslint:all", "plugin:@typescript-eslint/all", "prettier"],
   "rules": {
     "sort-imports": "off",
+		"no-duplicate-imports": "off",
     "no-console": "off",
     "one-var": "off",
     "sort-keys": "off",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ import { SignatureModal } from './pages/Login/SignatureModal'
 import { AnimatePresence, LazyMotion, domAnimation, m } from 'framer-motion'
 
 const App = () => {
-  const { chatClientProxy, userPubkey, registeredKey, registerMessage } = useContext(W3iContext)
+  const { chatClientProxy, userPubkey, uiEnabled, registeredKey, registerMessage } =
+    useContext(W3iContext)
   const {
     isProfileModalOpen,
     isShareModalOpen,
@@ -82,7 +83,7 @@ const App = () => {
         >
           {chatClientProxy && (
             <Fragment>
-              <Sidebar />
+              {uiEnabled.settings ? <Sidebar /> : null}
               <Outlet />
               <ToastContainer />
               <AnimatePresence mode="wait">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -83,7 +83,7 @@ const App = () => {
         >
           {chatClientProxy && (
             <Fragment>
-              {uiEnabled.settings ? <Sidebar /> : null}
+              {uiEnabled.sidebar ? <Sidebar /> : null}
               <Outlet />
               <ToastContainer />
               <AnimatePresence mode="wait">

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -16,16 +16,28 @@ const SidebarItem: React.FC<{ children?: React.ReactNode }> = ({ children }) => 
 const Sidebar: React.FC = () => {
   const { pathname } = useLocation()
   const navigationPaths = useMemo(() => pathname.split('/'), [pathname])
-  const { userPubkey } = useContext(W3iContext)
+  const { userPubkey, uiEnabled } = useContext(W3iContext)
   const isMobile = useIsMobile()
-  const navItems = useMemo(
-    () => [
-      [<MessageIcon isFilled={pathname.includes('/messages')} />, 'messages'],
-      [<NotificationIcon isFilled={pathname.includes('/notifications')} />, 'notifications'],
-      [<SettingIcon isFilled={pathname.includes('/settings')} />, 'settings']
-    ],
-    [pathname]
-  )
+  const navItems = useMemo(() => {
+    const items: [React.ReactNode, string][] = []
+
+    if (uiEnabled.chat) {
+      items.push([<MessageIcon isFilled={pathname.includes('/messages')} />, 'messages'])
+    }
+
+    if (uiEnabled.push) {
+      items.push([
+        <NotificationIcon isFilled={pathname.includes('/notifications')} />,
+        'notifications'
+      ])
+    }
+
+    if (uiEnabled.settings) {
+      items.push([<SettingIcon isFilled={pathname.includes('/settings')} />, 'settings'])
+    }
+
+    return items
+  }, [pathname, uiEnabled])
 
   // If pathname matches .*/.*/.*
   // As per design, sidebar in mobile is hidden when on "Main" is viewed on messages
@@ -42,11 +54,7 @@ const Sidebar: React.FC = () => {
       <SidebarItem>
         <div className="Sidebar__Navigation">
           {navItems.map(([icon, itemName]) => (
-            <Link
-              className="Sidebar__Navigation__Link"
-              key={itemName as string}
-              to={`/${itemName as string}`}
-            >
+            <Link className="Sidebar__Navigation__Link" key={itemName} to={`/${itemName}`}>
               {icon}
             </Link>
           ))}

--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -5,6 +5,13 @@ import type { Dispatch, SetStateAction } from 'react'
 import { createContext } from 'react'
 import type { W3iChatClient, W3iPushClient } from '../../w3iProxy'
 
+export interface UiEnabled {
+  chat: boolean
+  push: boolean
+  settings: boolean
+  sidebar: boolean
+}
+
 interface W3iContextState {
   chatClientProxy: W3iChatClient | null
   registeredKey: string | null
@@ -20,6 +27,7 @@ interface W3iContextState {
   registerMessage: string | null
   chatProvider: string
   pushProvider: string
+  uiEnabled: UiEnabled
 }
 
 const W3iContext = createContext<W3iContextState>({
@@ -32,6 +40,7 @@ const W3iContext = createContext<W3iContextState>({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setUserPubkey: () => {},
   threads: [],
+  uiEnabled: { chat: true, push: true, settings: true, sidebar: true },
   activeSubscriptions: [],
   sentInvites: [],
   invites: [],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,28 +2,15 @@ import { EthereumClient, w3mConnectors, w3mProvider } from '@web3modal/ethereum'
 import { Web3Modal } from '@web3modal/react'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { configureChains, createClient, WagmiConfig } from 'wagmi'
 import { mainnet, polygon, optimism, arbitrum } from 'wagmi/chains'
-import App from './App'
-import Web3InboxPlaceholder from './components/general/Web3InboxPlaceholder'
-import ChatInvites from './components/messages/ChatInvites'
-import MessagesLayout from './components/messages/MessagesLayout'
-import NewChat from './components/messages/NewChat'
-import ThreadWindow from './components/messages/ThreadWindow'
-import AppExplorer from './components/notifications/AppExplorer'
-import AppNotifications from './components/notifications/AppNotifications'
-import NotificationsLayout from './components/notifications/NotificationsLayout'
-import Settings from './components/settings/Settings'
-import SettingsLayout from './components/settings/SettingsLayout'
 import SettingsContextProvider from './contexts/SettingsContext'
 import W3iContextProvider from './contexts/W3iContext'
 import './index.css'
-import Login from './pages/Login'
 import './styles/fonts.css'
 import { AnimatePresence } from 'framer-motion'
-import ScanQrCode from './pages/ScanQrCode'
-import DirectInvite from './components/messages/DirectInvite'
+import ConfiguredRoutes from './routes'
 
 const projectId = import.meta.env.VITE_PROJECT_ID
 
@@ -43,33 +30,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <SettingsContextProvider>
         <BrowserRouter>
           <W3iContextProvider>
-            <AnimatePresence mode="wait">
-              <Routes>
-                <Route path="/login" element={<Login />} />
-
-                <Route path="/qrcode-scan" element={<ScanQrCode />} />
-
-                <Route path="/" element={<App />}>
-                  <Route path="notifications" element={<NotificationsLayout />}>
-                    <Route index element={<Web3InboxPlaceholder />} />
-                    <Route path="/notifications/new-app" element={<AppExplorer />} />
-                    <Route path="/notifications/:topic" element={<AppNotifications />} />
-                  </Route>
-                  <Route path="messages" element={<MessagesLayout />}>
-                    <Route index element={<Web3InboxPlaceholder />} />
-                    <Route path="/messages/chat/:peer" element={<ThreadWindow />} />
-                    <Route path="/messages/new-chat" element={<NewChat />} />
-                    <Route path="/messages/chat-invites" element={<ChatInvites />} />
-                    <Route path="/messages/invite/:account" element={<DirectInvite />} />
-                  </Route>
-                  <Route path="settings" element={<SettingsLayout />}>
-                    <Route index element={<Settings />} />
-                  </Route>
-                </Route>
-
-                <Route index element={<Navigate to={`/messages`} />} />
-              </Routes>
-            </AnimatePresence>
+            <AnimatePresence mode="wait"></AnimatePresence>
+            <ConfiguredRoutes />
           </W3iContextProvider>
         </BrowserRouter>
       </SettingsContextProvider>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -31,21 +31,29 @@ const Web3InboxFeatures = [
 ]
 
 const Login: React.FC = () => {
-  const { userPubkey, chatProvider, registeredKey, registerMessage } = useContext(W3iContext)
+  const { userPubkey, chatProvider, uiEnabled, registeredKey, registerMessage } =
+    useContext(W3iContext)
   const { search } = useLocation()
   const next = new URLSearchParams(search).get('next')
   const nav = useNavigate()
 
+  console.log({ userPubkey, uiEnabled })
+
   useEffect(() => {
+    const path = next ? decodeURIComponent(next) : '/'
+    // If chat is not enabled, there is no need to register right away.
+    if (userPubkey && !uiEnabled.chat) {
+      nav(path)
+    }
+
     if (userPubkey && registeredKey) {
-      const path = next ? decodeURIComponent(next) : '/'
       nav(path)
     }
 
     if (userPubkey && !registeredKey && registerMessage) {
       signatureModalService.openModal()
     }
-  }, [userPubkey, next, registeredKey, registerMessage])
+  }, [userPubkey, next, registeredKey, uiEnabled, registerMessage])
 
   if (chatProvider !== 'internal') {
     return (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,64 @@
+import App from './App'
+import Web3InboxPlaceholder from './components/general/Web3InboxPlaceholder'
+import ChatInvites from './components/messages/ChatInvites'
+import MessagesLayout from './components/messages/MessagesLayout'
+import NewChat from './components/messages/NewChat'
+import ThreadWindow from './components/messages/ThreadWindow'
+import AppExplorer from './components/notifications/AppExplorer'
+import AppNotifications from './components/notifications/AppNotifications'
+import NotificationsLayout from './components/notifications/NotificationsLayout'
+import Settings from './components/settings/Settings'
+import SettingsLayout from './components/settings/SettingsLayout'
+import Login from './pages/Login'
+import ScanQrCode from './pages/ScanQrCode'
+import DirectInvite from './components/messages/DirectInvite'
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { useContext } from 'react'
+import W3iContext from './contexts/W3iContext/context'
+
+const ConfiguredRoutes: React.FC = () => {
+  const { uiEnabled } = useContext(W3iContext)
+
+  const defaultPage =
+    Object.entries({
+      '/messages': uiEnabled.chat,
+      '/notifications': uiEnabled.push,
+      '/settings': uiEnabled.settings
+    }).find(([_, enabled]) => enabled)?.[0] ?? '/login'
+
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+
+      <Route path="/qrcode-scan" element={<ScanQrCode />} />
+
+      <Route path="/" element={<App />}>
+        {uiEnabled.push ? (
+          <Route path="notifications" element={<NotificationsLayout />}>
+            <Route index element={<Web3InboxPlaceholder />} />
+            <Route path="/notifications/new-app" element={<AppExplorer />} />
+            <Route path="/notifications/:topic" element={<AppNotifications />} />
+          </Route>
+        ) : null}
+        {uiEnabled.chat ? (
+          <Route path="messages" element={<MessagesLayout />}>
+            <Route index element={<Web3InboxPlaceholder />} />
+            <Route path="/messages/chat/:peer" element={<ThreadWindow />} />
+            <Route path="/messages/new-chat" element={<NewChat />} />
+            <Route path="/messages/chat-invites" element={<ChatInvites />} />
+            <Route path="/messages/invite/:account" element={<DirectInvite />} />
+          </Route>
+        ) : null}
+        {uiEnabled.settings ? (
+          <Route path="settings" element={<SettingsLayout />}>
+            <Route index element={<Settings />} />
+          </Route>
+        ) : null}
+      </Route>
+
+      <Route index element={<Navigate to={defaultPage} />} />
+    </Routes>
+  )
+}
+
+export default ConfiguredRoutes

--- a/src/w3iProxy/index.ts
+++ b/src/w3iProxy/index.ts
@@ -63,7 +63,10 @@ class Web3InboxProxy {
       projectId: this.projectId
     })
 
-    // Not disabling chatClient as it manages the account
+    /*
+     * Has to be init'd even if uiEnabled.chat is false due to the fact it
+     * currently manages account
+     */
     if (this.chatProvider === 'internal') {
       this.chatClient = await ChatClient.init({
         projectId: this.projectId,

--- a/src/w3iProxy/index.ts
+++ b/src/w3iProxy/index.ts
@@ -1,6 +1,7 @@
 import ChatClient from '@walletconnect/chat-client'
 import { Core } from '@walletconnect/core'
 import { WalletClient as PushWalletClient } from '@walletconnect/push-client'
+import { UiEnabled } from '../contexts/W3iContext/context'
 import W3iChatFacade from './w3iChatFacade'
 import W3iPushFacade from './w3iPushFacade'
 
@@ -22,6 +23,7 @@ class Web3InboxProxy {
   private pushClient?: PushWalletClient
   private readonly relayUrl?: string
   private readonly projectId: string
+  private readonly uiEnabled: UiEnabled
 
   /**
    *
@@ -30,7 +32,8 @@ class Web3InboxProxy {
     chatProvider: Web3InboxProxy['chatProvider'],
     pushProvider: Web3InboxProxy['pushProvider'],
     projectId: string,
-    relayUrl: string
+    relayUrl: string,
+    uiEnabled: UiEnabled
   ) {
     // Bind Chat properties
     this.chatProvider = chatProvider
@@ -41,6 +44,7 @@ class Web3InboxProxy {
     // Bind other configuration properties
     this.relayUrl = relayUrl
     this.projectId = projectId
+    this.uiEnabled = uiEnabled
     window.web3inbox = this
   }
 
@@ -59,24 +63,20 @@ class Web3InboxProxy {
       projectId: this.projectId
     })
 
-    console.log('this.chatProvider', this.chatProvider)
-    console.log('this.pushProvider', this.pushProvider)
-
+    // Not disabling chatClient as it manages the account
     if (this.chatProvider === 'internal') {
       this.chatClient = await ChatClient.init({
         projectId: this.projectId,
         core,
         keyserverUrl: 'https://keys.walletconnect.com'
       })
-      console.log('this.chatClient', this.chatClient)
       await this.chatFacade.initInternalProvider(this.chatClient)
     }
 
-    if (this.pushProvider === 'internal') {
+    if (this.pushProvider === 'internal' && this.uiEnabled.push) {
       this.pushClient = await PushWalletClient.init({
         core
       })
-      console.log('this.pushClient', this.pushClient)
 
       this.pushFacade.initInternalProvider(this.pushClient)
     }


### PR DESCRIPTION
# Description

Allow to configure UIs by setting relevant flags in params: `chatEnabled`, `pushEnabled` and `settingsEnabled`.  They are enabled by default.

If only one is enabled, the sidebar is hidden.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves 

Fixes #101 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information

**Note**: Even if `chatEnabled=false`, a `chatProvider=external` must still be provided as the chat proxy is what handles accounts, for now. 
