### PR TITLE
Refactor to use auth provider

### DIFF
--- a/src/components/general/Checkbox/index.tsx
+++ b/src/components/general/Checkbox/index.tsx
@@ -12,13 +12,10 @@ interface CheckboxProps {
 const Checkbox: React.FC<CheckboxProps> = ({ name, checked, id, onCheck, onUncheck }) => {
   const handleChange = useCallback(
     (ev: React.ChangeEvent<HTMLInputElement>) => {
-      console.log({ evChecked: ev.target.checked })
       if (ev.target.checked && onCheck) {
-        console.log('Calling onCheck')
         onCheck()
       }
       if (!ev.target.checked && onUncheck) {
-        console.log('Calling onUnCheck')
         onUncheck()
       }
     },

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -89,7 +89,6 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
 
   useEffect(() => {
     if (authClient) {
-      console.log('Setting account since client is init', authClient.getAccount())
       setUserPubkey(authClient.getAccount())
     }
   }, [authClient, setUserPubkey])

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -9,6 +9,7 @@ import type { PushClientTypes } from '@walletconnect/push-client'
 import { useLocation } from 'react-router-dom'
 import { useDisconnect } from 'wagmi'
 import { subscribeModalService } from '../../utils/store'
+import type W3iAuthFacade from '../../w3iProxy/w3iAuthFacade'
 
 interface W3iContextProviderProps {
   children: React.ReactNode | React.ReactNode[]
@@ -22,6 +23,9 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
   const query = new URLSearchParams(window.location.search)
   const chatProviderQuery = query.get('chatProvider')
   const pushProviderQuery = query.get('pushProvider')
+  const authProviderQuery = query.get('authProvider')
+
+  const { search } = useLocation()
 
   // CHAT STATE
   const [chatProvider] = useState(
@@ -36,13 +40,17 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     PushClientTypes.PushSubscription[]
   >([])
 
-  const [userPubkey, setUserPubkey] = useState<string | undefined>(undefined)
-  const { search } = useLocation()
-
   // PUSH STATE
   const [pushClient, setPushClient] = useState<W3iPushClient | null>(null)
   const [pushProvider] = useState(
     pushProviderQuery ? (pushProviderQuery as Web3InboxProxy['pushProvider']) : 'internal'
+  )
+
+  // AUTH STATE
+  const [userPubkey, setUserPubkey] = useState<string | undefined>(undefined)
+  const [authClient, setAuthClient] = useState<W3iAuthFacade | null>(null)
+  const [authProvider] = useState(
+    authProviderQuery ? (authProviderQuery as Web3InboxProxy['authProvider']) : 'internal'
   )
 
   const disconnect = useCallback(() => {
@@ -75,39 +83,54 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     const account = new URLSearchParams(search).get('account')
 
     if (account) {
-      setUserPubkey(account)
-      setRegistered(null)
+      authClient?.setAccount(account)
     }
-  }, [search, setUserPubkey])
+  }, [search, setUserPubkey, authClient])
 
   useEffect(() => {
-    const sub = chatClient?.observe('chat_account_change', {
+    if (authClient) {
+      console.log('Setting account since client is init', authClient.getAccount())
+      setUserPubkey(authClient.getAccount())
+    }
+  }, [authClient, setUserPubkey])
+
+  useEffect(() => {
+    const sub = authClient?.observe('auth_set_account', {
       next: ({ account }) => {
+        console.log('Got set account')
         setUserPubkey(account)
         setRegistered(null)
       }
     })
 
     return () => sub?.unsubscribe()
-  }, [chatClient])
+  }, [authClient, setUserPubkey, setRegistered])
 
   useEffect(() => {
-    if (chatClient && pushClient) {
+    if (chatClient && pushClient && authClient) {
       return
     }
 
-    const w3iProxy = new Web3InboxProxy(chatProvider, pushProvider, projectId, relayUrl, uiEnabled)
+    const w3iProxy = new Web3InboxProxy(
+      chatProvider,
+      pushProvider,
+      authProvider,
+      projectId,
+      relayUrl,
+      uiEnabled
+    )
     w3iProxy
       .init()
       .then(() => setChatClient(w3iProxy.chat))
+      .then(() => setAuthClient(w3iProxy.auth))
+      .then(() => setPushClient(w3iProxy.push))
       .then(() => {
-        const account = w3iProxy.chat.getAccount()
+        const account = authClient?.getAccount()
         if (account) {
           setUserPubkey(account)
         }
       })
-      .then(() => setPushClient(w3iProxy.push))
-  }, [setChatClient, chatClient, setUserPubkey, setPushClient, pushClient])
+  }, [setChatClient, chatClient, setUserPubkey, setPushClient, pushClient, setAuthClient])
 
   const refreshPushState = useCallback(() => {
     if (!pushClient || !userPubkey) {

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -48,10 +48,20 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
 
   // AUTH STATE
   const [userPubkey, setUserPubkey] = useState<string | undefined>(undefined)
+  console.log({ userPubkey })
   const [authClient, setAuthClient] = useState<W3iAuthFacade | null>(null)
+  const [accountQueryParam, setAccountQueryParam] = useState('')
   const [authProvider] = useState(
     authProviderQuery ? (authProviderQuery as Web3InboxProxy['authProvider']) : 'internal'
   )
+
+  useEffect(() => {
+    const account = new URLSearchParams(search).get('account')
+
+    if (account) {
+      setAccountQueryParam(account)
+    }
+  }, [search])
 
   const disconnect = useCallback(() => {
     setUserPubkey(undefined)
@@ -80,12 +90,11 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
   }
 
   useEffect(() => {
-    const account = new URLSearchParams(search).get('account')
-
-    if (account) {
-      authClient?.setAccount(account)
+    console.log({ settingQueryParamAccount: accountQueryParam, authClient: Boolean(authClient) })
+    if (accountQueryParam && authClient) {
+      authClient.setAccount(accountQueryParam)
     }
-  }, [search, setUserPubkey, authClient])
+  }, [accountQueryParam, setUserPubkey, authClient])
 
   useEffect(() => {
     if (authClient) {

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -37,8 +37,6 @@ const Login: React.FC = () => {
   const next = new URLSearchParams(search).get('next')
   const nav = useNavigate()
 
-  console.log({ userPubkey, uiEnabled })
-
   useEffect(() => {
     const path = next ? decodeURIComponent(next) : '/'
     // If chat is not enabled, there is no need to register right away.

--- a/src/pages/ScanQrCode/index.tsx
+++ b/src/pages/ScanQrCode/index.tsx
@@ -14,8 +14,6 @@ const ScanQrCode: React.FC = () => {
       return
     }
 
-    console.log({ scanResult })
-
     const web3inboxRegex = new RegExp(`${window.location.origin}/messages/invite/.*`, 'u')
 
     if (web3inboxRegex.test(scanResult)) {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -9,8 +9,6 @@ export const formatEthChainsAddress = (address: string | undefined) => {
     return ''
   }
 
-  console.log({ formatted: `eip155:1:${address}` })
-
   return `eip155:1:${address}`
 }
 

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -258,7 +258,6 @@ export const useMobileResponsiveGrid = () => {
       return
     }
 
-    console.log('Setting entries to none')
     Object.entries(displays).forEach(([cssKey]) => {
       ref.current?.style.setProperty(cssKey, 'none')
     })

--- a/src/w3iProxy/authProviders/externalAuthProvider.ts
+++ b/src/w3iProxy/authProviders/externalAuthProvider.ts
@@ -1,0 +1,59 @@
+import type { JsonRpcRequest } from '@walletconnect/jsonrpc-types'
+import { AndroidCommunicator } from '../externalCommunicators/androidCommunicator'
+import { IOSCommunicator } from '../externalCommunicators/iosCommunicator'
+import { JsCommunicator } from '../externalCommunicators/jsCommunicator'
+import { ReactNativeCommunicator } from '../externalCommunicators/reactNativeCommunicator'
+import type { ExternalCommunicator } from '../externalCommunicators/communicatorType'
+import type { EventEmitter } from 'events'
+
+export default class ExternalAuthProvider {
+  protected readonly emitter: EventEmitter
+  protected readonly communicator: ExternalCommunicator
+  public providerName = 'ExternalAuthProvider'
+
+  private readonly methodsListenedTo = ['auth_set_account']
+
+  private account?: string
+
+  public constructor(emitter: EventEmitter, name: string) {
+    this.emitter = emitter
+
+    switch (name) {
+      case 'android':
+        this.communicator = new AndroidCommunicator(this.emitter)
+        break
+      case 'ios':
+        this.communicator = new IOSCommunicator(this.emitter)
+        break
+      case 'reactnative':
+        this.communicator = new ReactNativeCommunicator(this.emitter)
+        break
+      default:
+        this.communicator = new JsCommunicator(this.emitter)
+        break
+    }
+  }
+
+  public isListeningToMethodFromPostMessage(method: string) {
+    return this.methodsListenedTo.includes(method)
+  }
+
+  public handleMessage(request: JsonRpcRequest<unknown>) {
+    switch (request.method) {
+      case 'setAccount':
+        this.account = (request.params as { account: string }).account
+        this.emitter.emit('auth_account_change', request.params)
+        break
+      default:
+        throw new Error(`Method ${request.method} unsupported by provider ${this.providerName}`)
+    }
+  }
+
+  public getAccount() {
+    return this.account
+  }
+
+  public setAccount(account: string) {
+    this.account = account
+  }
+}

--- a/src/w3iProxy/authProviders/internalAuthProvider.ts
+++ b/src/w3iProxy/authProviders/internalAuthProvider.ts
@@ -1,0 +1,55 @@
+import { getAccount, watchAccount } from '@wagmi/core'
+import type { JsonRpcRequest } from '@walletconnect/jsonrpc-types'
+import type { EventEmitter } from 'events'
+
+export default class InternalAuthProvider {
+  private readonly methodsListenedTo = ['auth_set_account']
+  public providerName = 'InternalAuthProvider'
+  public account?: string
+  protected readonly emitter: EventEmitter
+
+  public constructor(emitter: EventEmitter, _name = 'InternalAuthProvider') {
+    this.emitter = emitter
+    watchAccount(account => {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      if (!account.address || !window.web3inbox.chat) {
+        return
+      }
+
+      this.emitter.emit('auth_set_account', { account })
+    })
+  }
+
+  public isListeningToMethodFromPostMessage(method: string) {
+    return this.methodsListenedTo.includes(method)
+  }
+
+  public handleMessage(request: JsonRpcRequest<unknown>) {
+    switch (request.method) {
+      case 'setAccount':
+        this.account = (request.params as { account: string }).account
+        this.emitter.emit('auth_set_account', request.params)
+        break
+      default:
+        throw new Error(`Method ${request.method} unsupported by provider ${this.providerName}`)
+    }
+  }
+
+  public async initState() {
+    this.account = getAccount().address
+    if (this.account) {
+      console.log('Emitting account')
+      this.emitter.emit('auth_set_account', { account: this.account })
+    }
+
+    return Promise.resolve()
+  }
+
+  public getAccount() {
+    return this.account
+  }
+
+  public setAccount(account: string) {
+    this.account = account
+  }
+}

--- a/src/w3iProxy/authProviders/internalAuthProvider.ts
+++ b/src/w3iProxy/authProviders/internalAuthProvider.ts
@@ -38,7 +38,6 @@ export default class InternalAuthProvider {
   public async initState() {
     this.account = getAccount().address
     if (this.account) {
-      console.log('Emitting account')
       this.emitter.emit('auth_set_account', { account: this.account })
     }
 

--- a/src/w3iProxy/authProviders/types.ts
+++ b/src/w3iProxy/authProviders/types.ts
@@ -1,0 +1,12 @@
+import type { NextObserver, Observable } from 'rxjs'
+
+export interface AuthFacadeEvents {
+  auth_set_account: { account: string }
+}
+export type ObservableMap = Map<
+  keyof AuthFacadeEvents,
+  Observable<AuthFacadeEvents[keyof AuthFacadeEvents]>
+>
+
+export type AuthEventObserver<K extends keyof AuthFacadeEvents> = NextObserver<AuthFacadeEvents[K]>
+export type AuthEventObservable<K extends keyof AuthFacadeEvents> = Observable<AuthFacadeEvents[K]>

--- a/src/w3iProxy/chatProviders/externalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/externalChatProvider.ts
@@ -17,8 +17,7 @@ export default class ExternalChatProvider implements W3iChatProvider {
     'chat_invite_accepted',
     'chat_invite_rejected',
     'chat_left',
-    'chat_ping',
-    'chat_set_account'
+    'chat_ping'
   ]
   public providerName = 'ExternalChatProvider'
 

--- a/src/w3iProxy/chatProviders/internalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/internalChatProvider.ts
@@ -233,8 +233,6 @@ export default class InternalChatProvider implements W3iChatProvider {
 
     const isConnected = this.chatClient.core.relayer.provider.connection.connected
 
-    console.log({ isConnected })
-
     try {
       await this.chatClient.message(params)
     } catch {

--- a/src/w3iProxy/chatProviders/internalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/internalChatProvider.ts
@@ -1,4 +1,4 @@
-import { getAccount, watchAccount } from '@wagmi/core'
+import { getAccount } from '@wagmi/core'
 import type { ChatClientTypes } from '@walletconnect/chat-client'
 import type { EventEmitter } from 'events'
 // eslint-disable-next-line no-duplicate-imports
@@ -45,22 +45,6 @@ export default class InternalChatProvider implements W3iChatProvider {
         this.chatClient.ping({ topic: '' })
       }
     })
-
-    watchAccount(account => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (!account.address || !window.web3inbox.chat) {
-        return
-      }
-
-      window.web3inbox.chat.postMessage({
-        id: Date.now(),
-        jsonrpc: '2.0',
-        method: 'setAccount',
-        params: {
-          account: account.address
-        }
-      })
-    })
   }
 
   /*
@@ -70,18 +54,6 @@ export default class InternalChatProvider implements W3iChatProvider {
   public async initState(chatClient: ChatClient) {
     this.chatClient = chatClient
     this.projectId = this.chatClient.projectId
-
-    const address: string | undefined = getAccount().address
-    if (address) {
-      window.web3inbox.chat.postMessage({
-        id: Date.now(),
-        jsonrpc: '2.0',
-        method: 'setAccount',
-        params: {
-          account: address
-        }
-      })
-    }
 
     await this.mutedContacts.init()
 

--- a/src/w3iProxy/index.ts
+++ b/src/w3iProxy/index.ts
@@ -2,6 +2,7 @@ import ChatClient from '@walletconnect/chat-client'
 import { Core } from '@walletconnect/core'
 import { WalletClient as PushWalletClient } from '@walletconnect/push-client'
 import type { UiEnabled } from '../contexts/W3iContext/context'
+import W3iAuthFacade from './w3iAuthFacade'
 import W3iChatFacade from './w3iChatFacade'
 import W3iPushFacade from './w3iPushFacade'
 
@@ -21,6 +22,8 @@ class Web3InboxProxy {
   private readonly pushFacade: W3iPushFacade
   private readonly pushProvider: W3iPushFacade['providerName']
   private pushClient?: PushWalletClient
+  private readonly authFacade: W3iAuthFacade
+  private readonly authProvider: W3iAuthFacade['providerName']
   private readonly relayUrl?: string
   private readonly projectId: string
   private readonly uiEnabled: UiEnabled
@@ -31,6 +34,7 @@ class Web3InboxProxy {
   public constructor(
     chatProvider: Web3InboxProxy['chatProvider'],
     pushProvider: Web3InboxProxy['pushProvider'],
+    authProvider: Web3InboxProxy['authProvider'],
     projectId: string,
     relayUrl: string,
     uiEnabled: UiEnabled
@@ -41,6 +45,9 @@ class Web3InboxProxy {
     // Bind Push properties
     this.pushProvider = pushProvider
     this.pushFacade = new W3iPushFacade(this.pushProvider)
+    // Bind Auth Properties
+    this.authProvider = authProvider
+    this.authFacade = new W3iAuthFacade(this.authProvider)
     // Bind other configuration properties
     this.relayUrl = relayUrl
     this.projectId = projectId
@@ -54,6 +61,10 @@ class Web3InboxProxy {
 
   public get push(): W3iPushFacade {
     return this.pushFacade
+  }
+
+  public get auth(): W3iAuthFacade {
+    return this.authFacade
   }
 
   public async init() {
@@ -82,6 +93,10 @@ class Web3InboxProxy {
       })
 
       this.pushFacade.initInternalProvider(this.pushClient)
+    }
+
+    if (this.authProvider === 'internal') {
+      this.authFacade.initInternalProvider()
     }
   }
 }

--- a/src/w3iProxy/w3iAuthFacade.ts
+++ b/src/w3iProxy/w3iAuthFacade.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events'
+import type { JsonRpcRequest } from '@walletconnect/jsonrpc-types'
+import ExternalAuthProvider from './authProviders/externalAuthProvider'
+import InternalAuthProvider from './authProviders/internalAuthProvider'
+import type {
+  AuthEventObservable,
+  AuthEventObserver,
+  AuthFacadeEvents,
+  ObservableMap
+} from './authProviders/types'
+import { fromEvent } from 'rxjs'
+
+class W3iAuthFacade {
+  private readonly providerMap = {
+    internal: InternalAuthProvider,
+    external: ExternalAuthProvider,
+    ios: ExternalAuthProvider,
+    reactnative: ExternalAuthProvider,
+    android: ExternalAuthProvider
+  }
+  private readonly providerName: keyof typeof this.providerMap
+  private readonly observables: ObservableMap
+  private readonly emitter: EventEmitter
+  private readonly provider: ExternalAuthProvider | InternalAuthProvider
+
+  public constructor(providerName: W3iAuthFacade['providerName']) {
+    this.providerName = providerName
+    this.observables = new Map()
+    this.emitter = new EventEmitter()
+    const ProviderClass = this.providerMap[this.providerName]
+    this.provider = new ProviderClass(this.emitter, providerName)
+  }
+
+  // Method to be used by external providers. Not internal use.
+  public postMessage(messageData: JsonRpcRequest<unknown>) {
+    this.emitter.emit(messageData.id.toString(), messageData)
+    switch (messageData.method) {
+      default:
+        if (this.provider.isListeningToMethodFromPostMessage(messageData.method)) {
+          this.provider.handleMessage(messageData)
+        }
+    }
+  }
+
+  public async initInternalProvider() {
+    const internalProvider = this.provider as InternalAuthProvider
+    await internalProvider.initState()
+  }
+
+  public getAccount() {
+    return this.provider.getAccount()
+  }
+
+  public setAccount(account: string) {
+    this.provider.setAccount(account)
+
+    this.emitter.emit('auth_set_account', { account })
+  }
+
+  public observe<K extends keyof AuthFacadeEvents>(eventName: K, observer: AuthEventObserver<K>) {
+    const observableExists = this.observables.has(eventName)
+    if (!observableExists) {
+      this.observables.set(eventName, fromEvent(this.emitter, eventName) as AuthEventObservable<K>)
+    }
+    const eventObservable = this.observables.get(eventName) as AuthEventObservable<K>
+
+    const subscription = eventObservable.subscribe(observer)
+
+    return subscription
+  }
+}
+
+export default W3iAuthFacade


### PR DESCRIPTION
# Description
- Add dedicated auth facade
- Refactor userPubKey in app to use auth facade
- Remove old/useless console.log

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Notes
For w3iSdk, implementing this using the `account` query param will not change anything, but for dynamic account changing, the `setAccount` rpc request needs to go through `window.web3inbox.auth` not `window.web3inbox.chat`. 

The only change needed `account` query param is adding `authProvider=external` in the query params 