### PR TITLE
Hookup unsubscribe modal

### DIFF
--- a/src/components/notifications/AppNotifications/AppNotificationDropdown/index.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationDropdown/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from 'react'
 import W3iContext from '../../../../contexts/W3iContext/context'
-import { preferencesModalService } from '../../../../utils/store'
+import { preferencesModalService, unsubscribeModalService } from '../../../../utils/store'
 import Dropdown from '../../../general/Dropdown/Dropdown'
 import NotificationMuteIcon from '../../../general/Icon/NotificationMuteIcon'
 import SettingIcon from '../../../general/Icon/SettingIcon'
@@ -23,12 +23,11 @@ const AppNotificationDropdown: React.FC<IAppNotificationDropdownProps> = ({
 }) => {
   const { pushClientProxy } = useContext(W3iContext)
 
-  // TODO: Trigger notification modal
   const handleUnsubscribe = useCallback(() => {
-    pushClientProxy?.deleteSubscription({ topic: notificationId }).then(closeDropdown)
-  }, [notificationId, closeDropdown, pushClientProxy])
+    closeDropdown()
+    unsubscribeModalService.toggleModal(notificationId)
+  }, [notificationId, closeDropdown, unsubscribeModalService, pushClientProxy])
 
-  // TODO: Trigger notification preferences modal
   const handleOpenNotificationPreferencesModal = useCallback(() => {
     preferencesModalService.toggleModal(notificationId)
     closeDropdown()

--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -1,6 +1,6 @@
 import type { PushClientTypes } from '@walletconnect/push-client'
 import { createContext, useContext, useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { Navigate, useParams } from 'react-router-dom'
 import { noop } from 'rxjs'
 import W3iContext from '../../../contexts/W3iContext/context'
 import AppNotificationItem from './AppNotificationItem'
@@ -92,7 +92,7 @@ const AppNotifications = () => {
       </div>
     </AppNotificationDragContext.Provider>
   ) : (
-    <div>404</div>
+    <Navigate to="/notifications" />
   )
 }
 

--- a/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
@@ -11,17 +11,21 @@ import './UnsubscribeModal.scss'
 export const UnsubscribeModal: React.FC = () => {
   const { mode } = useContext(SettingsContext)
   const themeColors = useColorModeValue(mode)
-  const { activeSubscriptions } = useContext(W3iContext)
+  const { activeSubscriptions, pushClientProxy } = useContext(W3iContext)
   const { unsubscribeModalAppId } = useModals()
 
   const app = useMemo(
-    () => activeSubscriptions.find(mockApp => mockApp.topic === unsubscribeModalAppId),
+    () => activeSubscriptions.find(activeApp => activeApp.topic === unsubscribeModalAppId),
     [unsubscribeModalAppId]
   )
 
   const handleUnsubscribe = useCallback(() => {
-    unsubscribeModalService.closeModal()
-  }, [])
+    if (pushClientProxy && unsubscribeModalAppId) {
+      pushClientProxy
+        .deleteSubscription({ topic: unsubscribeModalAppId })
+        .then(() => unsubscribeModalService.closeModal())
+    }
+  }, [pushClientProxy, unsubscribeModalAppId])
 
   if (!app) {
     return null


### PR DESCRIPTION
# Description

- Hookup unsub modal
- Redirect `/notifications` instead of display 404 when going to a non-existing app

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
