### PR TITLE
Fix timestamp not being correct

### DIFF
--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -78,8 +78,9 @@ const AppNotifications = () => {
             <AppNotificationItem
               key={notification.id}
               notification={{
-                timestamp: Date.now(),
-                isRead: false,
+                timestamp: notification.publishedAt,
+                // We do not manage read status for now.
+                isRead: true,
                 id: notification.id.toString(),
                 message: notification.message.body,
                 title: notification.message.title,


### PR DESCRIPTION
# Description

- Use `publishedAt` instead of `Date.now()`
- Change `read` to default to `false` since we do manage read status at the moment.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
