### PR TITLE
[:fix] replacing min-height to max-height small viewport

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -5,7 +5,7 @@
   --header-display: unset;
   --main-display: unset;
   background: var(--bg-color-1);
-  min-height: 100vh;
+  max-height: 100svh;
   display: grid;
   gap: 3em;
   grid-template: var(--grid-template);
@@ -37,7 +37,7 @@
     padding-bottom: 0.75em;
     grid-area: main;
     max-width: 100vw;
-    height: 100vh;
+    height: 100svh;
     overflow-x: hidden;
 
     display: var(--main-display);


### PR DESCRIPTION
# Description

I replaced the min-height: 100vh with max-height: 100svh. This will cause the scrollbar to be locked on Safari browsers on mobile. In my opinion, this provides the best UX for mobile users as it gives a more native feel. It also prevents scrolling outside of the main thread, which would otherwise mess up the UI.

# Type of change



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves https://github.com/WalletConnect/web3inbox/issues/146

# Examples/Screenshots (Optional)

Please test on an iOS device:

[web3inbox-dev-hidden-git-fix-ios-messagebox-walletconnect1.vercel.app](https://web3inbox-dev-hidden-git-fix-ios-messagebox-walletconnect1.vercel.app/)
# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

