### PR TITLE
Refactor to use central observablesController

### DIFF
--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -37,8 +37,10 @@ const AppCard: React.FC<AppCardProps> = ({ name, description, logo, bgColor, url
       }
 
       try {
-        pushClientProxy?.once('push_subscription', () => {
-          showSuccessMessageToast(`Subscribed to ${name}`)
+        pushClientProxy?.observeOne('push_subscription', {
+          next: () => {
+            showSuccessMessageToast(`Subscribed to ${name}`)
+          }
         })
         await pushClientProxy?.subscribe({
           account: `eip155:1:${userPubkey}`,

--- a/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
@@ -45,9 +45,11 @@ export const PreferencesModal: React.FC = () => {
       const topic = preferencesModalAppId
 
       try {
-        pushClientProxy?.once('push_update', () => {
-          preferencesModalService.closeModal()
-          showSuccessMessageToast('Preferences updated successfully')
+        pushClientProxy?.observeOne('push_update', {
+          next: () => {
+            preferencesModalService.closeModal()
+            showSuccessMessageToast('Preferences updated successfully')
+          }
         })
         await pushClientProxy?.update({
           topic,

--- a/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
@@ -22,8 +22,10 @@ export const UnsubscribeModal: React.FC = () => {
   const handleUnsubscribe = useCallback(async () => {
     if (pushClientProxy && unsubscribeModalAppId) {
       try {
-        pushClientProxy.once('push_delete', () => {
-          unsubscribeModalService.closeModal()
+        pushClientProxy.observeOne('push_delete', {
+          next: () => {
+            unsubscribeModalService.closeModal()
+          }
         })
         await pushClientProxy.deleteSubscription({ topic: unsubscribeModalAppId })
       } catch (error) {

--- a/src/w3iProxy/authProviders/types.ts
+++ b/src/w3iProxy/authProviders/types.ts
@@ -1,12 +1,3 @@
-import type { NextObserver, Observable } from 'rxjs'
-
 export interface AuthFacadeEvents {
   auth_set_account: { account: string }
 }
-export type ObservableMap = Map<
-  keyof AuthFacadeEvents,
-  Observable<AuthFacadeEvents[keyof AuthFacadeEvents]>
->
-
-export type AuthEventObserver<K extends keyof AuthFacadeEvents> = NextObserver<AuthFacadeEvents[K]>
-export type AuthEventObservable<K extends keyof AuthFacadeEvents> = Observable<AuthFacadeEvents[K]>

--- a/src/w3iProxy/chatProviders/types.ts
+++ b/src/w3iProxy/chatProviders/types.ts
@@ -1,7 +1,5 @@
 import type ChatClient from '@walletconnect/chat-client'
 import type { JsonRpcRequest } from '@walletconnect/jsonrpc-utils'
-import type { NextObserver, Observable } from 'rxjs'
-import type { ChatFacadeEvents } from '../listenerTypes'
 
 // Omitting chat client management keys
 type NonFunctionChatClientKeys =
@@ -54,14 +52,6 @@ interface ModifiedChatClientFunctions {
   muteContact: (params: { topic: string }) => Promise<void>
   unmuteContact: (params: { topic: string }) => Promise<void>
 }
-
-export type ObservableMap = Map<
-  keyof ChatFacadeEvents,
-  Observable<ChatFacadeEvents[keyof ChatFacadeEvents]>
->
-
-export type ChatEventObserver<K extends keyof ChatFacadeEvents> = NextObserver<ChatFacadeEvents[K]>
-export type ChatEventObservable<K extends keyof ChatFacadeEvents> = Observable<ChatFacadeEvents[K]>
 
 export type ChatClientFunctions = ModifiedChatClientFunctions &
   Omit<ChatClient, NonFunctionChatClientKeys>

--- a/src/w3iProxy/observablesController.ts
+++ b/src/w3iProxy/observablesController.ts
@@ -3,8 +3,6 @@ import type { NextObserver, Observable } from 'rxjs'
 import { take } from 'rxjs'
 import { fromEvent } from 'rxjs'
 
-type StringKey<K> = Exclude<K, number | symbol>
-
 export class ObservablesController<Events> {
   private readonly observables: Map<keyof Events, Observable<Events[keyof Events]>>
   private readonly emitter: EventEmitter
@@ -14,7 +12,7 @@ export class ObservablesController<Events> {
     this.observables = new Map()
   }
 
-  private getObservable<K extends keyof Events>(eventName: StringKey<K>) {
+  private getObservable<K extends string & keyof Events>(eventName: K) {
     const observableExists = this.observables.has(eventName)
     if (!observableExists) {
       this.observables.set(eventName, fromEvent(this.emitter, eventName) as Observable<Events[K]>)
@@ -23,10 +21,7 @@ export class ObservablesController<Events> {
     return this.observables.get(eventName) as Observable<Events[K]>
   }
 
-  public observe<K extends keyof Events>(
-    eventName: StringKey<K>,
-    observer: NextObserver<Events[K]>
-  ) {
+  public observe<K extends string & keyof Events>(eventName: K, observer: NextObserver<Events[K]>) {
     const eventObservable = this.getObservable(eventName)
 
     const subscription = eventObservable.subscribe(observer)
@@ -34,8 +29,8 @@ export class ObservablesController<Events> {
     return subscription
   }
 
-  public observeOne<K extends keyof Events>(
-    eventName: StringKey<K>,
+  public observeOne<K extends string & keyof Events>(
+    eventName: K,
     observer: NextObserver<Events[K]>
   ) {
     const eventObservable = this.getObservable(eventName)

--- a/src/w3iProxy/observablesController.ts
+++ b/src/w3iProxy/observablesController.ts
@@ -1,0 +1,52 @@
+import type { EventEmitter } from 'events'
+import type { NextObserver, Observable } from 'rxjs'
+import { take } from 'rxjs'
+import { fromEvent } from 'rxjs'
+
+type StringKey<K> = Exclude<K, number | symbol>
+
+export class ObservablesController<Events> {
+  private readonly observables: Map<keyof Events, Observable<Events[keyof Events]>>
+  private readonly emitter: EventEmitter
+
+  public constructor(emitter: EventEmitter) {
+    this.emitter = emitter
+    this.observables = new Map()
+  }
+
+  private getObservable<K extends keyof Events>(eventName: StringKey<K>) {
+    const observableExists = this.observables.has(eventName)
+    if (!observableExists) {
+      this.observables.set(eventName, fromEvent(this.emitter, eventName) as Observable<Events[K]>)
+    }
+
+    return this.observables.get(eventName) as Observable<Events[K]>
+  }
+
+  public observe<K extends keyof Events>(
+    eventName: StringKey<K>,
+    observer: NextObserver<Events[K]>
+  ) {
+    const eventObservable = this.getObservable(eventName)
+
+    const subscription = eventObservable.subscribe(observer)
+
+    return subscription
+  }
+
+  public observeOne<K extends keyof Events>(
+    eventName: StringKey<K>,
+    observer: NextObserver<Events[K]>
+  ) {
+    const eventObservable = this.getObservable(eventName)
+
+    const subscription = eventObservable.pipe(take(1)).subscribe({
+      next: observer.next,
+      error: observer.error,
+      complete: () => {
+        observer.complete?.()
+        subscription.unsubscribe()
+      }
+    })
+  }
+}

--- a/src/w3iProxy/pushProviders/types.ts
+++ b/src/w3iProxy/pushProviders/types.ts
@@ -43,14 +43,6 @@ interface ModifiedPushClientFunctions {
   ) => Promise<ReturnType<PushWalletClient['getMessageHistory']>>
 }
 
-export type PushObservableMap = Map<
-  keyof PushFacadeEvents,
-  Observable<PushFacadeEvents[keyof PushFacadeEvents]>
->
-
-export type PushEventObserver<K extends keyof PushFacadeEvents> = NextObserver<PushFacadeEvents[K]>
-export type PushEventObservable<K extends keyof PushFacadeEvents> = Observable<PushFacadeEvents[K]>
-
 export type PushClientFunctions = Omit<PushWalletClient, NonMethodPushClientKeys>
 export type W3iPush = ModifiedPushClientFunctions &
   Omit<PushClientFunctions, keyof ModifiedPushClientFunctions>

--- a/src/w3iProxy/w3iPushFacade.ts
+++ b/src/w3iProxy/w3iPushFacade.ts
@@ -1,16 +1,11 @@
 import { EventEmitter } from 'events'
 import type { JsonRpcRequest } from '@walletconnect/jsonrpc-utils'
-import { fromEvent } from 'rxjs'
 import type { PushClientTypes, WalletClient as PushWalletClient } from '@walletconnect/push-client'
-import type {
-  PushEventObservable,
-  PushEventObserver,
-  PushObservableMap,
-  W3iPush
-} from './pushProviders/types'
+import type { W3iPush } from './pushProviders/types'
 import ExternalPushProvider from './pushProviders/externalPushProvider'
 import InternalPushProvider from './pushProviders/internalPushProvider'
 import type { PushFacadeEvents } from './listenerTypes'
+import { ObservablesController } from './observablesController'
 
 class W3iPushFacade implements W3iPush {
   private readonly providerMap = {
@@ -22,14 +17,13 @@ class W3iPushFacade implements W3iPush {
   }
   private readonly providerName: keyof typeof this.providerMap
   private readonly emitter: EventEmitter
-  private readonly observables: PushObservableMap
-
+  private readonly observablesController: ObservablesController<PushFacadeEvents>
   private readonly provider: ExternalPushProvider | InternalPushProvider
 
   public constructor(providerName: W3iPushFacade['providerName']) {
     this.providerName = providerName
-    this.observables = new Map()
     this.emitter = new EventEmitter()
+    this.observablesController = new ObservablesController(this.emitter)
 
     const ProviderClass = this.providerMap[this.providerName]
     this.provider = new ProviderClass(this.emitter, providerName)
@@ -48,16 +42,12 @@ class W3iPushFacade implements W3iPush {
     }
   }
 
-  public observe<K extends keyof PushFacadeEvents>(eventName: K, observer: PushEventObserver<K>) {
-    const observableExists = this.observables.has(eventName)
-    if (!observableExists) {
-      this.observables.set(eventName, fromEvent(this.emitter, eventName) as PushEventObservable<K>)
-    }
-    const eventObservable = this.observables.get(eventName) as PushEventObservable<K>
+  public get observe() {
+    return this.observablesController.observe
+  }
 
-    const subscription = eventObservable.subscribe(observer)
-
-    return subscription
+  public get observeOne() {
+    return this.observablesController.observeOne
   }
 
   // ------------------ Push Client Forwarding ------------------
@@ -94,24 +84,6 @@ class W3iPushFacade implements W3iPush {
 
   public async deletePushMessage(params: { id: number }) {
     return this.provider.deletePushMessage(params)
-  }
-
-  // ------------------ Event Forwarding ------------------
-
-  public on(eventName: string, listener: (data: unknown) => void) {
-    this.emitter.on(eventName, listener)
-  }
-
-  public once(eventName: string, listener: (data: unknown) => void) {
-    this.emitter.once(eventName, listener)
-  }
-
-  public removeListener(eventName: string, listener: (data: unknown) => void) {
-    this.emitter.removeListener(eventName, listener)
-  }
-
-  public removeAllListeners(eventName: string) {
-    this.emitter.removeAllListeners(eventName)
   }
 }
 


### PR DESCRIPTION
# Description

- Add `ObservablesController` which removes a lot of the copy paste in observing between the facades
- `once` -> `observeOne`

# Type of change

- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Context
- Removing direct access from the emitter promotes using the observables, which has two main benefits:
  - enforces consistent dev experience across the entire app
  - maintains the ability to `pipe` stuff to observers in the future in case we need to
- We don't need `off` or `removeListener` since when subscribing to a observer, you have access to the `subscription` object and take complete ownership of it
