### PR TITLE
adding padding around back button

### DIFF
--- a/src/components/general/BackButton/BackButton.scss
+++ b/src/components/general/BackButton/BackButton.scss
@@ -5,4 +5,5 @@
   align-items: center;
   gap: 0.535em;
   color: var(--accent-color-1);
+  padding: 15px 10px;
 }

--- a/src/components/general/BackButton/BackButton.scss
+++ b/src/components/general/BackButton/BackButton.scss
@@ -6,4 +6,8 @@
   gap: 0.535em;
   color: var(--accent-color-1);
   padding: 15px 10px;
+
+  &__Title {
+    margin-top: 1px;
+  }
 }

--- a/src/components/general/BackButton/index.tsx
+++ b/src/components/general/BackButton/index.tsx
@@ -41,7 +41,7 @@ const BackButton: React.FC<BackButtonProps> = ({ backTo, children, force }) => {
           fill="#3396FF"
         />
       </svg>
-      {children}
+      {children && <p className="BackButton__Title">{children}</p>}
     </div>
   ) : null
 }

--- a/src/components/messages/ThreadWindow/ThreadWindow.scss
+++ b/src/components/messages/ThreadWindow/ThreadWindow.scss
@@ -20,6 +20,10 @@
     backdrop-filter: blur(10px);
     align-items: center;
     font-size: 1.25em;
+    @media only screen and (max-width: 700px) {
+      gap: 0.8em;
+      padding: 0em calc(0.625em - 0.4em);
+    }
   }
 
   &__messages {


### PR DESCRIPTION
# Description

Adjusted some padding & margins for a correct UI & bigger tap area for back button

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves https://github.com/WalletConnect/web3inbox/issues/152

