### PR TITLE
Bind observe functions

### DIFF
--- a/src/w3iProxy/observablesController.ts
+++ b/src/w3iProxy/observablesController.ts
@@ -10,6 +10,8 @@ export class ObservablesController<Events> {
   public constructor(emitter: EventEmitter) {
     this.emitter = emitter
     this.observables = new Map()
+    this.observe = this.observe.bind(this)
+    this.observeOne = this.observeOne.bind(this)
   }
 
   private getObservable<K extends string & keyof Events>(eventName: K) {


### PR DESCRIPTION
# Description

The observe and observeOne functions were to bound to `this` and so were calling the parent facade as `this` which does not contain `getObservable` method. This fixes that.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
