### PR TITLE
[:feat] add empty state when there are no notifications

### DIFF
--- a/src/components/notifications/AppNotifications/AppNotifications.scss
+++ b/src/components/notifications/AppNotifications/AppNotifications.scss
@@ -4,6 +4,7 @@
   gap: 12px;
   width: 100%;
   padding-top: 6px;
+  height: 100%;
 
   &Actions {
     position: absolute;
@@ -60,6 +61,7 @@
   &__list {
     padding: 0 calc(1.25em - 0.4em) 0 calc(0.75em - 0.4em);
   }
+
   &__item {
     position: relative;
     display: flex;

--- a/src/components/notifications/AppNotifications/AppNotificationsEmpty/AppNotificationsEmpty.scss
+++ b/src/components/notifications/AppNotifications/AppNotificationsEmpty/AppNotificationsEmpty.scss
@@ -1,0 +1,34 @@
+.AppNotificationsEmpty {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  &__wrapper {
+    transform: translateY(-100%);
+  }
+
+  &__title {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 1.125em;
+    line-height: 1.375em;
+    text-align: center;
+    margin-top: 4px;
+  }
+
+  &__subtitle {
+    font-weight: 500;
+    font-size: 0.875em;
+    line-height: 1.0625em;
+    color: var(--fg-color-3);
+    text-align: center;
+    margin-top: 4px;
+  }
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    margin: 0 auto;
+  }
+}

--- a/src/components/notifications/AppNotifications/AppNotificationsEmpty/index.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationsEmpty/index.tsx
@@ -1,4 +1,5 @@
 import './AppNotificationsEmpty.scss'
+import Alarm from '../../../../assets/Alarm.png'
 
 const AppNotificationsEmpty: React.FC = () => {
   return (
@@ -6,7 +7,7 @@ const AppNotificationsEmpty: React.FC = () => {
       <div className="AppNotificationsEmpty__wrapper">
         <img
           className="AppNotificationsEmpty__icon"
-          src="/src/assets/Alarm.png"
+          src={Alarm}
           alt="Notifications Icon"
           loading="lazy"
         />

--- a/src/components/notifications/AppNotifications/AppNotificationsEmpty/index.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationsEmpty/index.tsx
@@ -1,0 +1,20 @@
+import './AppNotificationsEmpty.scss'
+
+const AppNotificationsEmpty: React.FC = () => {
+  return (
+    <div className="AppNotificationsEmpty">
+      <div className="AppNotificationsEmpty__wrapper">
+        <img
+          className="AppNotificationsEmpty__icon"
+          src="/src/assets/Alarm.png"
+          alt="Notifications Icon"
+          loading="lazy"
+        />
+        <p className="AppNotificationsEmpty__title">No notifications yet</p>
+        <p className="AppNotificationsEmpty__subtitle">Notifications will show up here</p>
+      </div>
+    </div>
+  )
+}
+
+export default AppNotificationsEmpty

--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -5,7 +5,9 @@ import { noop } from 'rxjs'
 import W3iContext from '../../../contexts/W3iContext/context'
 import AppNotificationItem from './AppNotificationItem'
 import './AppNotifications.scss'
+import IconWrapper from '../../general/Icon/IconWrapper/IconWrapper'
 import AppNotificationsHeader from './AppNotificationsHeader'
+import AppNotificationsEmpty from './AppNotificationsEmpty'
 
 export interface AppNotificationsDragProps {
   id: number
@@ -73,23 +75,29 @@ const AppNotifications = () => {
           name={app.metadata.name}
           logo={app.metadata.icons[0]}
         />
-        <div className="AppNotifications__list">
-          {notifications.map(notification => (
-            <AppNotificationItem
-              key={notification.id}
-              notification={{
-                timestamp: notification.publishedAt,
-                // We do not manage read status for now.
-                isRead: true,
-                id: notification.id.toString(),
-                message: notification.message.body,
-                title: notification.message.title,
-                image: notification.message.icon
-              }}
-              appLogo={app.metadata.icons[0]}
-            />
-          ))}
-        </div>
+        {notifications.length > 0 ? (
+          <div className="AppNotifications__list">
+            <>
+              {notifications.map(notification => (
+                <AppNotificationItem
+                  key={notification.id}
+                  notification={{
+                    timestamp: notification.publishedAt,
+                    // We do not manage read status for now.
+                    isRead: true,
+                    id: notification.id.toString(),
+                    message: notification.message.body,
+                    title: notification.message.title,
+                    image: notification.message.icon
+                  }}
+                  appLogo={app.metadata.icons[0]}
+                />
+              ))}
+            </>
+          </div>
+        ) : (
+          <AppNotificationsEmpty />
+        )}
       </div>
     </AppNotificationDragContext.Provider>
   ) : (


### PR DESCRIPTION
# Description

I've added an empty state when there are no notifications

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves https://github.com/WalletConnect/web3inbox/issues/157

# Examples/Screenshots (Optional)

https://web3inbox-dev-hidden-git-feat-notificatio-6926ba-walletconnect1.vercel.app/login?next=%2Fmessages

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


