### PR TITLE
Chore/disable doubl register

### DIFF
--- a/src/contexts/W3iContext/hooks/pushHooks.ts
+++ b/src/contexts/W3iContext/hooks/pushHooks.ts
@@ -62,7 +62,12 @@ export const usePushState = (w3iProxy: Web3InboxProxy, proxyReady: boolean, dapp
   )
 
   useEffect(() => {
-    if (userPubkey) {
+    /*
+     * No need to register if chat is enabled since it will handle registration
+     * notify.register is disabled in favor of chat.register since
+     * chat.register performs an extra step.
+     */
+    if (userPubkey && !uiEnabled.chat) {
       handleRegistration(userPubkey)
     } else {
       setRegisterMessage(null)

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -49,8 +49,11 @@ const Login: React.FC = () => {
     const path = next ? decodeURIComponent(next) : '/'
 
     if (userPubkey) {
-      const chatConditionsPass = !uiEnabled.chat || chatRegisteredKey
-      const notifyConditionsPass = !uiEnabled.notify || pushRegisteredKey
+      const chatConditionsPass = Boolean(!uiEnabled.chat || chatRegisteredKey)
+      // Only need to trigger signatures for notify if none were issued for chat
+      const notifyConditionsPass = Boolean(uiEnabled.chat || !uiEnabled.notify || pushRegisteredKey)
+
+      console.log({ chatConditionsPass, notifyConditionsPass })
 
       if (chatConditionsPass && notifyConditionsPass) {
         nav(path)


### PR DESCRIPTION
# Description
- Only fire `register` from one client:
   - If `uiEnabled.chat && uiEnabled.notify`: Register from `chat`
   - If only one is enabled, register from the active one.
# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


