### PR TITLE
Revert "fix: resolve `.well-known` assets via app.browser field for testing

### DIFF
--- a/src/utils/hooks/usePushProjects.ts
+++ b/src/utils/hooks/usePushProjects.ts
@@ -15,12 +15,11 @@ const usePushProjects = () => {
 
       const pushProjects: IPushProject[] = Object.values(discoverableProjetsRes.listings)
       const pushApps: IPushApp[] = pushProjects.map(
-        ({ id, name, description, homepage, image_url, metadata, app }: IPushProject) => ({
+        ({ id, name, description, homepage, image_url, metadata }: IPushProject) => ({
           id,
           name,
           description,
-          // TODO: use only `homepage` here again once we have separate gm-dapp entries between Push and Notify.
-          url: app.browser || homepage,
+          url: homepage,
           icons: [image_url.md],
           colors: metadata.colors
         })

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -23,9 +23,6 @@ export interface IPushProject {
   name: string
   description: string
   homepage: string
-  app: {
-    browser: string
-  }
   image_url: {
     sm: string
     md: string


### PR DESCRIPTION
This reverts commit 1b6688d18f2700b22aa2cdf1b96a58d14062e238.

# Description

- This was a workaround/override behaviour we used on the notify refactor branch to specifically target `notify.gm.walletconnect.com` in the w3i explorer
- `gm-dapp`'s homepage field has now been updated so this is no longer needed, i.e. we should always point to the `homepage` field going forward as before.


