### PR TITLE
Fix/init push sync stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "prettier:write": "prettier --write '**/*.{js,ts,jsx,tsx,scss}'"
   },
   "dependencies": {
-    "@walletconnect/chat-client": "^0.7.6",
+    "@walletconnect/chat-client": "^0.7.8",
     "@walletconnect/core": "^2.9.2",
-    "@walletconnect/notify-client": "^0.1.5",
+    "@walletconnect/notify-client": "^0.11.2",
     "@walletconnect/notify-message-decrypter": "^0.1.0",
-    "@walletconnect/sync-client": "^0.3.7",
+    "@walletconnect/sync-client": "^0.3.8",
     "@web3modal/ethereum": "^2.6.2",
     "@web3modal/react": "^2.6.2",
     "classnames": "^2.3.2",

--- a/src/contexts/W3iContext/hooks/pushHooks.ts
+++ b/src/contexts/W3iContext/hooks/pushHooks.ts
@@ -32,14 +32,14 @@ export const usePushState = (w3iProxy: Web3InboxProxy, proxyReady: boolean, dapp
   }, [w3iProxy, proxyReady])
 
   const refreshPushState = useCallback(() => {
-    if (!pushClient || !userPubkey) {
+    if (!proxyReady || !pushClient || !userPubkey) {
       return
     }
 
     pushClient.getActiveSubscriptions({ account: `eip155:1:${userPubkey}` }).then(subscriptions => {
       setActiveSubscriptions(Object.values(subscriptions))
     })
-  }, [pushClient, userPubkey])
+  }, [pushClient, userPubkey, proxyReady])
 
   useEffect(() => {
     // Account for sync init
@@ -108,7 +108,6 @@ export const usePushState = (w3iProxy: Web3InboxProxy, proxyReady: boolean, dapp
     })
 
     return () => {
-      // PushRequestSub.unsubscribe()
       pushSubscriptionSub.unsubscribe()
       syncUpdateSub.unsubscribe()
       pushUpdateSub.unsubscribe()

--- a/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
+++ b/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
@@ -28,14 +28,13 @@ export const useW3iProxy = () => {
   )
 
   useEffect(() => {
-    setReady(oldReady => {
-      if (!oldReady) {
-        w3iProxy.init()
-      }
-
-      return true
-    })
-  }, [w3iProxy, setReady])
+    if (w3iProxy.isInitializing) {
+      return
+    }
+    if (!w3iProxy.getInitComplete()) {
+      w3iProxy.init().then(() => setReady(true))
+    }
+  }, [w3iProxy.isInitializing])
 
   return [w3iProxy, ready] as [Web3InboxProxy, boolean]
 }

--- a/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
+++ b/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
@@ -28,7 +28,13 @@ export const useW3iProxy = () => {
   )
 
   useEffect(() => {
-    w3iProxy.init().then(() => setReady(true))
+    setReady(oldReady => {
+      if (!oldReady) {
+        w3iProxy.init()
+      }
+
+      return true
+    })
   }, [w3iProxy, setReady])
 
   return [w3iProxy, ready] as [Web3InboxProxy, boolean]

--- a/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
+++ b/src/contexts/W3iContext/hooks/w3iProxyHooks.ts
@@ -32,7 +32,7 @@ export const useW3iProxy = () => {
       return
     }
     if (!w3iProxy.getInitComplete()) {
-      w3iProxy.init().then(() => setReady(true))
+      w3iProxy.init().then(() => setReady(true)).catch(error => { console.error("w3iProxy failed to initialize: ", error) })
     }
   }, [w3iProxy.isInitializing])
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -53,8 +53,6 @@ const Login: React.FC = () => {
       // Only need to trigger signatures for notify if none were issued for chat
       const notifyConditionsPass = Boolean(uiEnabled.chat || !uiEnabled.notify || pushRegisteredKey)
 
-      console.log({ chatRegisteredKey })
-
       if (chatConditionsPass && notifyConditionsPass) {
         nav(path)
         // Else if signature is required.

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -53,6 +53,8 @@ const Login: React.FC = () => {
       // Only need to trigger signatures for notify if none were issued for chat
       const notifyConditionsPass = Boolean(uiEnabled.chat || !uiEnabled.notify || pushRegisteredKey)
 
+      console.log({ chatRegisteredKey })
+
       if (chatConditionsPass && notifyConditionsPass) {
         nav(path)
         // Else if signature is required.

--- a/src/w3iProxy/authProviders/internalAuthProvider.ts
+++ b/src/w3iProxy/authProviders/internalAuthProvider.ts
@@ -19,6 +19,7 @@ export default class InternalAuthProvider {
       }
 
       this.emitter.emit('auth_set_account', { account: account.address })
+      this.account = account.address
     })
   }
 

--- a/src/w3iProxy/chatProviders/internalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/internalChatProvider.ts
@@ -242,21 +242,31 @@ export default class InternalChatProvider implements W3iChatProvider {
       throw new Error(this.formatClientRelatedError('register'))
     }
 
-    console.log('internalChatProvider > register > account:', params.account)
+    try {
+      const registeredIdentityKey = await this.chatClient.register({
+        ...params,
+        onSign: async message => {
+          this.emitter.emit('chat_signature_requested', { message })
 
-    return this.chatClient.register({
-      ...params,
-      onSign: async message => {
-        this.emitter.emit('chat_signature_requested', { message })
-
-        return new Promise(resolve => {
-          this.emitter.on('chat_signature_delivered', ({ signature }: { signature: string }) => {
-            console.log('Signature: ', signature)
-            resolve(signature)
+          return new Promise(resolve => {
+            this.emitter.on('chat_signature_delivered', ({ signature }: { signature: string }) => {
+              console.log('Signature: ', signature)
+              resolve(signature)
+            })
           })
-        })
-      }
-    })
+        }
+      })
+
+      return registeredIdentityKey
+    } catch (e) {
+      /*
+       * Right now, chat client's register doesn't work 100% of the time
+       * This essentially fulfills this function's API by returning the identity key
+       * However - the invite key is failing to register
+       * TODO: Fix underlying bug in chat client
+       */
+      return this.chatClient.identityKeys.getIdentity({ account: params.account })
+    }
   }
 
   public async resolve(params: { account: string }) {

--- a/src/w3iProxy/chatProviders/internalChatProvider.ts
+++ b/src/w3iProxy/chatProviders/internalChatProvider.ts
@@ -250,7 +250,6 @@ export default class InternalChatProvider implements W3iChatProvider {
 
           return new Promise(resolve => {
             this.emitter.on('chat_signature_delivered', ({ signature }: { signature: string }) => {
-              console.log('Signature: ', signature)
               resolve(signature)
             })
           })

--- a/src/w3iProxy/index.ts
+++ b/src/w3iProxy/index.ts
@@ -163,8 +163,6 @@ class Web3InboxProxy {
 
     this.initializing = true
 
-    console.log('INITIALIZING :)')
-
     // If core is initialized, we should init sync because some SDK needs it
     if (!this.syncClient && this.core) {
       this.syncClient = await SyncClient.init({
@@ -176,8 +174,6 @@ class Web3InboxProxy {
     if (this.core) {
       this.identityKeys = new IdentityKeys(this.core)
     }
-
-    console.log('>< Initting chat client')
     if (this.chatProvider === 'internal' && this.uiEnabled.chat && !this.chatClient) {
       this.chatClient = await ChatClient.init({
         projectId: this.projectId,
@@ -191,13 +187,9 @@ class Web3InboxProxy {
       await this.chatFacade.initInternalProvider(this.chatClient)
     }
 
-    console.log('>< Initting auth provider')
-
     if (this.authProvider === 'internal') {
       this.authFacade.initInternalProvider()
     }
-
-    console.log('>< Initting push provider')
 
     if (this.pushProvider === 'internal' && this.uiEnabled.notify && !this.pushClient) {
       this.pushClient = await NotifyClient.init({
@@ -210,26 +202,14 @@ class Web3InboxProxy {
 
       this.pushFacade.initInternalProvider(this.pushClient)
 
-      console.log('>< trying to use chat provider')
       if (this.chatClient) {
         this.chatClient.once('sync_stores_initialized', () => {
-          console.log('>< popped event')
           const account = this.auth.getAccount()
-          console.log('>< account', account)
           if (this.pushClient && account) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const signature = this.chatClient!.syncClient!.signatures.get(
               `eip155:1:${account}`
             )!.signature
-
-            console.log(
-              'Plain',
-              this.syncClient?.storeMap.keys,
-              'Chat',
-              this.chatClient?.syncClient?.storeMap.keys,
-              'Push',
-              this.pushClient.syncClient.storeMap.keys
-            )
 
             this.pushClient.initSyncStores({
               account: `eip155:1:${account}`,

--- a/src/w3iProxy/index.ts
+++ b/src/w3iProxy/index.ts
@@ -156,6 +156,8 @@ class Web3InboxProxy {
       return
     }
 
+    console.log('INITIALIZING :)')
+
     // If core is initialized, we should init sync because some SDK needs it
     if (!this.syncClient && this.core) {
       this.syncClient = await SyncClient.init({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2812,10 +2812,10 @@
     "@ethersproject/transactions" "^5.7.0"
     isomorphic-unfetch "^3.1.0"
 
-"@walletconnect/chat-client@^0.7.6":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/chat-client/-/chat-client-0.7.6.tgz#4dd1b691020525b8b77068475616d03b6fa9b85d"
-  integrity sha512-gaQBhaAdud8WEOKYdBTu+6GDpgfVFpScXvA23gEI1pFRvxcpcCzcU7CvmkXi5oGhCqkuO2eouW2uWyXfXOITZA==
+"@walletconnect/chat-client@^0.7.8":
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/chat-client/-/chat-client-0.7.8.tgz#5476775d70aff48b666c6ed080c42aba91653147"
+  integrity sha512-X/lyZTQzZpG2F5koYSDTXm+/BETTKjGuvgIIz3TO+hsFZSJQCqez3lRKcraCPu8OTVMfzxq6mSh3s2NYYhMnNA==
   dependencies:
     "@noble/ed25519" "^1.7.1"
     "@walletconnect/cacao" "^1.0.2"
@@ -2858,28 +2858,6 @@
 "@walletconnect/core@^2.7.3", "@walletconnect/core@^2.7.8", "@walletconnect/core@^2.8.0", "@walletconnect/core@^2.9.1", "@walletconnect/core@^2.9.2":
   version "2.9.2"
   resolved "https://registry.npmjs.org/@walletconnect/core/-/core-2.9.2.tgz"
-  integrity sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==
-  dependencies:
-    "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-provider" "1.0.13"
-    "@walletconnect/jsonrpc-types" "1.0.3"
-    "@walletconnect/jsonrpc-utils" "1.0.8"
-    "@walletconnect/jsonrpc-ws-connection" "1.0.13"
-    "@walletconnect/keyvaluestorage" "^1.0.2"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/relay-auth" "^1.0.4"
-    "@walletconnect/safe-json" "^1.0.2"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.9.2"
-    "@walletconnect/utils" "2.9.2"
-    events "^3.3.0"
-    lodash.isequal "4.5.0"
-    uint8arrays "^3.1.0"
-
-"@walletconnect/core@^2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.9.2.tgz#c46734ca63771b28fd77606fd521930b7ecfc5e1"
   integrity sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==
   dependencies:
     "@walletconnect/heartbeat" "1.2.1"
@@ -3169,10 +3147,10 @@
     "@walletconnect/modal-core" "2.5.4"
     "@walletconnect/modal-ui" "2.5.4"
 
-"@walletconnect/notify-client@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.1.5.tgz#fae425050774a4ebc52329189f4643610eccdd72"
-  integrity sha512-2vRCLTbU8LDmbM+3Uvmn7lknT7HCXu1iLfK69GTvJoYgHx27+ovnycCZCASL39+FZjO/O1VwvlSMr9sXdSv8xQ==
+"@walletconnect/notify-client@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.11.2.tgz#778802461134305bb0960cae5fe4f1304742cb38"
+  integrity sha512-ghmZPltklYO+gVl0tsYiFRcj7Q13Kne2y1ZWT5DkEXXDaV+1lY+lGljAMPb6UCmOI+uXMtzhCdS03rubw0+hEQ==
   dependencies:
     "@noble/ed25519" "^1.7.3"
     "@walletconnect/cacao" "1.0.2"
@@ -3181,7 +3159,7 @@
     "@walletconnect/history" "^1.0.4"
     "@walletconnect/identity-keys" "0.1.10"
     "@walletconnect/jsonrpc-utils" "1.0.7"
-    "@walletconnect/sync-client" "^0.3.7"
+    "@walletconnect/sync-client" "^0.3.8"
     "@walletconnect/time" "1.0.2"
     "@walletconnect/utils" "^2.9.1"
     axios "^1.4.0"
@@ -3247,10 +3225,10 @@
     "@walletconnect/utils" "2.8.4"
     events "^3.3.0"
 
-"@walletconnect/sync-client@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.npmjs.org/@walletconnect/sync-client/-/sync-client-0.3.7.tgz"
-  integrity sha512-+5sPhX81aBqWcaZARNUDEMwBVgA4UPMS2OCKDyl3xykFYbwXBRxSG0z/XJm1o9leboM9fjnXRWFUqOVqwhDtBg==
+"@walletconnect/sync-client@^0.3.8":
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sync-client/-/sync-client-0.3.8.tgz#b710f3ad78cf39e900aee392149ce99c912e1351"
+  integrity sha512-7tPq+WnluUc9k5b+md0UnNTp+OcFEomVsggUA8mLvS0xQlLl5FaobDCAtrzt+oJwq4yYtBRYot5Qwo5FyYlAwg==
   dependencies:
     "@ethersproject/wallet" "^5.7.0"
     "@walletconnect/core" "^2.8.0"
@@ -3315,18 +3293,6 @@
     "@walletconnect/logger" "^2.0.1"
     events "^3.3.0"
 
-"@walletconnect/types@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.9.2.tgz#d5fd5a61dc0f41cbdca59d1885b85207ac7bf8c5"
-  integrity sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==
-  dependencies:
-    "@walletconnect/events" "^1.0.1"
-    "@walletconnect/heartbeat" "1.2.1"
-    "@walletconnect/jsonrpc-types" "1.0.3"
-    "@walletconnect/keyvaluestorage" "^1.0.2"
-    "@walletconnect/logger" "^2.0.1"
-    events "^3.3.0"
-
 "@walletconnect/universal-provider@2.8.4":
   version "2.8.4"
   resolved "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.8.4.tgz"
@@ -3356,26 +3322,6 @@
     "@walletconnect/safe-json" "^1.0.2"
     "@walletconnect/time" "^1.0.2"
     "@walletconnect/types" "2.8.4"
-    "@walletconnect/window-getters" "^1.0.1"
-    "@walletconnect/window-metadata" "^1.0.1"
-    detect-browser "5.3.0"
-    query-string "7.1.3"
-    uint8arrays "^3.1.0"
-
-"@walletconnect/utils@2.9.2", "@walletconnect/utils@^2.9.1":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.9.2.tgz#035bdb859ee81a4bcc6420f56114cc5ec3e30afb"
-  integrity sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==
-  dependencies:
-    "@stablelib/chacha20poly1305" "1.0.1"
-    "@stablelib/hkdf" "1.0.1"
-    "@stablelib/random" "^1.0.2"
-    "@stablelib/sha256" "1.0.1"
-    "@stablelib/x25519" "^1.0.3"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/safe-json" "^1.0.2"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.9.2"
     "@walletconnect/window-getters" "^1.0.1"
     "@walletconnect/window-metadata" "^1.0.1"
     detect-browser "5.3.0"


### PR DESCRIPTION
# Description
## Sync Store Initializes
- Allow notify sync stores to be initialized once chat's sync stores are initialized. 
- Use event based method instead of `setTimeout`
## Init Data races
- `w3iProxy` was being initted *twice* by the `useEffect` in `w3iProxyHooks`.  Solved this by adding `initializing` state to the proxy
## Chat
- Chat's `register` method was sometimes failing to register invites. This error has been silenced and ignored. Function's API of returning identity key is maintained. However, registering invite key is not working and it shouldn't stop w3i from working at the moment.
- This was not caught before because of the following:
  - W3iProxy would run, attempt to initialize chat client. Succeed. Attempt to register. Fail and die
  - Second instance of W3iProxy (due to the above issue of it being initted twice) would initiate `notify` and `auth`

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)




# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
