### PR TITLE
Add failsafe

### DIFF
--- a/src/w3iProxy/pushProviders/internalPushProvider.ts
+++ b/src/w3iProxy/pushProviders/internalPushProvider.ts
@@ -118,6 +118,24 @@ export default class InternalPushProvider implements W3iPushProvider {
       throw new Error(this.formatClientRelatedError('subscribe'))
     }
     console.log('InternalPushProvider > PushClient.subscribe > params', params)
+    const currentSubs = Object.values(
+      this.pushClient.getActiveSubscriptions({ account: params.account })
+    )
+
+    /*
+     * We do nothing with this data so it's okay if we return garbage, for now.
+     * We do not have access to the RPC ID since there's a chance the subscription came in through
+     * sync, nor do we have access to sub auth.
+     * This is essentially a fail-safe if the UI goes out of sync.
+     * TODO: Move this functionality into notify client.
+     */
+    const targettedSub = currentSubs.find(sub => sub.metadata.url === params.metadata.url)
+    if (targettedSub) {
+      return {
+        id: 0,
+        subscriptionAuth: ''
+      }
+    }
 
     /*
      * To prevent subscribing in local/dev environemntns failing,


### PR DESCRIPTION
# Description

- Adding a couple of failsafes to account for the rare occurrence where the widget subscribe page does not detect if there's an active sub

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

