### PR TITLE
Add polling to account for history injection

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,3 @@
+// 1.5 seconds
+export const POLLING_TIMER = 1.5 * 1000
+export const POLL_COUNT = 3


### PR DESCRIPTION
# Description

There is no real way to know when history is done being injected since it emits different events based on fetched messages. Maybe down the line we could add a mechanism so that after fetching from history, we decode messages and add a counter.

However, this is going to take a lot of effort for something than can be achieved with polling

# Type of change



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

