### PR TITLE
Fix/presist settings

### DIFF
--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useReducer } from 'react'
 import { useColorModeValue } from '../../utils/hooks'
 import type { SettingsContextSimpleState, SettingsContextUpdate } from './context'
 import SettingsContext from './context'
-import { useWeb3ModalTheme } from '@web3modal/wagmi/react'
 
 interface ThemeContextProviderProps {
   children: React.ReactNode | React.ReactNode[]
@@ -16,25 +15,16 @@ const settingsReducer = (
 }
 
 const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children }) => {
-  const favoriteTheme =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    typeof localStorage === 'undefined' || !localStorage
-      ? null
-      : (localStorage.getItem('w3i-theme') as SettingsContextSimpleState['mode'] | null)
+  const localSettings = localStorage.getItem('w3i-settings')
 
-  const initialState: SettingsContextSimpleState = {
+  const initialState: SettingsContextSimpleState = localSettings? JSON.parse(localSettings) : {
     mode: 'light',
     newContacts: 'require-invite',
     isDevModeEnabled: true
   }
 
-  const { setThemeMode } = useWeb3ModalTheme()
   const [settingsState, updateSettings] = useReducer(settingsReducer, initialState)
   const themeColors = useColorModeValue(settingsState.mode)
-
-  useEffect(() => {
-    // SetThemeMode(favoriteTheme === 'light' ? 'light' : 'dark')
-  }, [setThemeMode, favoriteTheme])
 
   useEffect(() => {
     Object.entries(themeColors).forEach(([colorVariable, colorValue]) => {
@@ -42,6 +32,10 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
     })
   }, [themeColors])
 
+  useEffect(() => {
+    localStorage?.setItem("w3i-settings", JSON.stringify(settingsState))
+  }, [settingsState])
+  
   return (
     <SettingsContext.Provider
       value={{

--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -22,7 +22,7 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
   const initialState: SettingsContextSimpleState = localSettings? JSON.parse(localSettings) : {
     mode: 'light',
     newContacts: 'require-invite',
-    isDevModeEnabled: true
+    isDevModeEnabled: false
   }
 
   const [settingsState, updateSettings] = useReducer(settingsReducer, initialState)

--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -3,6 +3,8 @@ import { useColorModeValue } from '../../utils/hooks'
 import type { SettingsContextSimpleState, SettingsContextUpdate } from './context'
 import SettingsContext from './context'
 
+const LOCAL_SETTINGS_KEY = 'w3i-settings';
+
 interface ThemeContextProviderProps {
   children: React.ReactNode | React.ReactNode[]
 }
@@ -15,7 +17,7 @@ const settingsReducer = (
 }
 
 const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children }) => {
-  const localSettings = localStorage.getItem('w3i-settings')
+  const localSettings = localStorage.getItem(LOCAL_SETTINGS_KEY)
 
   const initialState: SettingsContextSimpleState = localSettings? JSON.parse(localSettings) : {
     mode: 'light',
@@ -33,7 +35,7 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
   }, [themeColors])
 
   useEffect(() => {
-    localStorage?.setItem("w3i-settings", JSON.stringify(settingsState))
+    localStorage?.setItem(LOCAL_SETTINGS_KEY, JSON.stringify(settingsState))
   }, [settingsState])
   
   return (


### PR DESCRIPTION
# Description

- Persist *all* `SettingsContext` settings in `localStorage`.
- On `SettingsContextProvider` init, use persisted settings.
- Remove `favoriteTheme` web3modal references as they were completely unused and we no longer need to persist `w3i-theme` by itself.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves #241 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
