### PR TITLE
Chore/analytics on dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build && yarn buildMessager",
+    "dev": "NODE_ENV=development yarn dev",
+    "build": "tsc && NODE_ENV=production vite build && yarn buildMessager",
     "buildMessager": "esbuild ./src/firebase-messaging-sw.ts --bundle --minify --outfile=./dist/firebase-messaging-sw.js",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "dev": "vite",
     "build": "tsc && vite build && yarn buildMessager",
     "buildMessager": "esbuild ./src/firebase-messaging-sw.ts --bundle --minify --outfile=./dist/firebase-messaging-sw.js",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development yarn dev",
-    "build": "tsc && NODE_ENV=production vite build && yarn buildMessager",
+    "dev": "vite dev",
+    "build": "tsc && vite build && yarn buildMessager",
     "buildMessager": "esbuild ./src/firebase-messaging-sw.ts --bundle --minify --outfile=./dist/firebase-messaging-sw.js",
     "preview": "vite preview",
     "lint": "eslint .",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,7 +29,7 @@ const wagmiConfig = defaultWagmiConfig({ chains, projectId, metadata })
 
 createWeb3Modal({
   wagmiConfig,
-  enableAnalytics: true,
+  enableAnalytics: process.env.NODE_ENV === 'production',
   chains,
   projectId,
   themeMode: 'light',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -29,12 +29,14 @@ const wagmiConfig = defaultWagmiConfig({ chains, projectId, metadata })
 
 createWeb3Modal({
   wagmiConfig,
-  enableAnalytics: process.env.NODE_ENV === 'production',
+  enableAnalytics: import.meta.env.PROD,
   chains,
   projectId,
   themeMode: 'light',
   themeVariables: { '--w3m-z-index': 9999 }
 })
+
+console.log({env: process.env.NODE_ENV})
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -36,8 +36,6 @@ createWeb3Modal({
   themeVariables: { '--w3m-z-index': 9999 }
 })
 
-console.log({env: process.env.NODE_ENV})
-
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
# Description

- use `import.meta.env.PROD` from vite to check if env is prod
- if it is, enableAnalytics
- tested by comparing a console.log of `import.meta.env.PROD` when running w3i locally between:
    - `yarn vite`:  `PROD === false`
    - `yarn build && yarn vite preview`: `PROD === true`

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

