### PR TITLE
fix: add imagefall back for app selector logo

### DIFF
--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -15,6 +15,7 @@ import Label from '../../general/Label'
 import Text from '../../general/Text'
 import MobileHeader from '../../layout/MobileHeader'
 import { AnimatePresence, motion } from 'framer-motion'
+import { handleImageFallback } from '../../../utils/ui'
 
 const AppSelector: React.FC = () => {
   const { pathname } = useLocation()
@@ -136,6 +137,7 @@ const AppSelector: React.FC = () => {
                               app.metadata.icons?.length ? app.metadata.icons[0] : '/fallback.svg'
                             }
                             alt={`${app.metadata.name} logo`}
+			    onError={handleImageFallback}
                             loading="lazy"
                           />
                           <div className="AppSelector__link__wrapper">


### PR DESCRIPTION
# Description

- Add `handleImageFallback` to app-selector logo
# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
