### PR TITLE
Feat/filter by appdomain

### DIFF
--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -17,6 +17,7 @@ import cn from 'classnames'
 import W3iContext from '../../../contexts/W3iContext/context'
 import { getDbEchoRegistrations } from '../../../utils/idb'
 import { useNotificationPermissionState } from '../../../utils/hooks/notificationHooks'
+import Input from '../../general/Input'
 
 const getHelperTooltip = () => {
   switch (Notification?.permission) {
@@ -117,6 +118,13 @@ const NotificationsSettings: React.FC = () => {
               )
             })}
           </div>
+          <SettingsItem
+            title="Filter By App Domain"
+            subtitle="Display a specific project using a domain"
+            className="NotificationsSettings__notifications"
+          >
+	    <Input />
+          </SettingsItem>
         </div>
       </motion.div>
     </AnimatePresence>

--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -123,7 +123,10 @@ const NotificationsSettings: React.FC = () => {
             subtitle="Display a specific project using a domain"
             className="NotificationsSettings__notifications"
           >
-	    <Input value={filterAppDomain} onChange={ev => updateSettings({filterAppDomain: ev.target.value})} />
+            <Input
+              value={filterAppDomain}
+              onChange={ev => updateSettings({ filterAppDomain: ev.target.value })}
+            />
           </SettingsItem>
         </div>
       </motion.div>

--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -31,7 +31,7 @@ const getHelperTooltip = () => {
 }
 
 const NotificationsSettings: React.FC = () => {
-  const { isDevModeEnabled, updateSettings } = useContext(SettingsContext)
+  const { isDevModeEnabled, updateSettings, filterAppDomain } = useContext(SettingsContext)
   const { notifyClientProxy } = useContext(W3iContext)
 
   const notificationsEnabled = useNotificationPermissionState()
@@ -123,7 +123,7 @@ const NotificationsSettings: React.FC = () => {
             subtitle="Display a specific project using a domain"
             className="NotificationsSettings__notifications"
           >
-	    <Input />
+	    <Input value={filterAppDomain} onChange={ev => updateSettings({filterAppDomain: ev.target.value})} />
           </SettingsItem>
         </div>
       </motion.div>

--- a/src/contexts/SettingsContext/context.ts
+++ b/src/contexts/SettingsContext/context.ts
@@ -5,8 +5,7 @@ export interface SettingsContextUpdate {
   mode?: 'dark' | 'light' | 'system'
   newContacts?: 'accept-new' | 'reject-new' | 'require-invite'
   isDevModeEnabled?: boolean
-  filterAppDomain: string
-  setFilterAppDomain: (newFilter: string) => void
+  filterAppDomain?: string
 }
 
 export type SettingsContextSimpleState = Required<SettingsContextUpdate>
@@ -20,7 +19,6 @@ const SettingsContext = createContext<SettingsContextState>({
   newContacts: 'require-invite',
   isDevModeEnabled: true,
   updateSettings: noop,
-  setFilterAppDomain: noop,
   filterAppDomain: ""
 })
 

--- a/src/contexts/SettingsContext/context.ts
+++ b/src/contexts/SettingsContext/context.ts
@@ -19,7 +19,7 @@ const SettingsContext = createContext<SettingsContextState>({
   newContacts: 'require-invite',
   isDevModeEnabled: true,
   updateSettings: noop,
-  filterAppDomain: ""
+  filterAppDomain: ''
 })
 
 export default SettingsContext

--- a/src/contexts/SettingsContext/context.ts
+++ b/src/contexts/SettingsContext/context.ts
@@ -1,9 +1,12 @@
 import { createContext } from 'react'
+import { noop } from '../../utils/general'
 
 export interface SettingsContextUpdate {
   mode?: 'dark' | 'light' | 'system'
   newContacts?: 'accept-new' | 'reject-new' | 'require-invite'
   isDevModeEnabled?: boolean
+  filterAppDomain: string
+  setFilterAppDomain: (newFilter: string) => void
 }
 
 export type SettingsContextSimpleState = Required<SettingsContextUpdate>
@@ -16,8 +19,9 @@ const SettingsContext = createContext<SettingsContextState>({
   mode: 'light',
   newContacts: 'require-invite',
   isDevModeEnabled: true,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  updateSettings: () => {}
+  updateSettings: noop,
+  setFilterAppDomain: noop,
+  filterAppDomain: ""
 })
 
 export default SettingsContext

--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -25,12 +25,11 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
     : {
         mode: 'light',
         newContacts: 'require-invite',
-        isDevModeEnabled: false
+      isDevModeEnabled: false,
+      filterAppDomain: ""
       }
 
   const [settingsState, updateSettings] = useReducer(settingsReducer, initialState)
-
-  const [filterAppDomain, setFilterAppDomain] = useState("");
 
   const themeColors = useColorModeValue(settingsState.mode)
 
@@ -49,8 +48,6 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
       value={{
         ...settingsState,
         updateSettings,
-	filterAppDomain,
-	setFilterAppDomain
       }}
     >
       {children}

--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from 'react'
+import React, { useEffect, useReducer, useState } from 'react'
 import { useColorModeValue } from '../../utils/hooks'
 import type { SettingsContextSimpleState, SettingsContextUpdate } from './context'
 import SettingsContext from './context'
@@ -19,6 +19,7 @@ const settingsReducer = (
 const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children }) => {
   const localSettings = localStorage.getItem(LOCAL_SETTINGS_KEY)
 
+
   const initialState: SettingsContextSimpleState = localSettings
     ? JSON.parse(localSettings)
     : {
@@ -28,6 +29,9 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
       }
 
   const [settingsState, updateSettings] = useReducer(settingsReducer, initialState)
+
+  const [filterAppDomain, setFilterAppDomain] = useState("");
+
   const themeColors = useColorModeValue(settingsState.mode)
 
   useEffect(() => {
@@ -44,7 +48,9 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
     <SettingsContext.Provider
       value={{
         ...settingsState,
-        updateSettings
+        updateSettings,
+	filterAppDomain,
+	setFilterAppDomain
       }}
     >
       {children}

--- a/src/contexts/SettingsContext/index.tsx
+++ b/src/contexts/SettingsContext/index.tsx
@@ -19,14 +19,13 @@ const settingsReducer = (
 const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children }) => {
   const localSettings = localStorage.getItem(LOCAL_SETTINGS_KEY)
 
-
   const initialState: SettingsContextSimpleState = localSettings
     ? JSON.parse(localSettings)
     : {
         mode: 'light',
         newContacts: 'require-invite',
-      isDevModeEnabled: false,
-      filterAppDomain: ""
+        isDevModeEnabled: false,
+        filterAppDomain: ''
       }
 
   const [settingsState, updateSettings] = useReducer(settingsReducer, initialState)
@@ -47,7 +46,7 @@ const SettingsContextProvider: React.FC<ThemeContextProviderProps> = ({ children
     <SettingsContext.Provider
       value={{
         ...settingsState,
-        updateSettings,
+        updateSettings
       }}
     >
       {children}

--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -54,7 +54,7 @@ const W3iContext = createContext<W3iContextState>({
   dappIcon: '',
   dappNotificationDescription: '',
   dappName: '',
-  chatClientProxy: null,
+  chatClientProxy: null
 })
 
 export default W3iContext

--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -54,7 +54,7 @@ const W3iContext = createContext<W3iContextState>({
   dappIcon: '',
   dappNotificationDescription: '',
   dappName: '',
-  chatClientProxy: null
+  chatClientProxy: null,
 })
 
 export default W3iContext

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -1,7 +1,5 @@
 import type { NotifyClientTypes } from '@walletconnect/notify-client'
-import { EventEmitter } from 'events'
 import { useCallback, useEffect, useState } from 'react'
-import { useLocation } from 'react-router-dom'
 import { noop } from 'rxjs'
 import type Web3InboxProxy from '../../../w3iProxy'
 import type { W3iNotifyClient } from '../../../w3iProxy'
@@ -11,7 +9,6 @@ import { useUiState } from './uiHooks'
 export const useNotifyState = (
   w3iProxy: Web3InboxProxy,
   proxyReady: boolean,
-  dappOrigin: string
 ) => {
   const [activeSubscriptions, setActiveSubscriptions] = useState<
     NotifyClientTypes.NotifySubscription[]

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -6,10 +6,7 @@ import type { W3iNotifyClient } from '../../../w3iProxy'
 import { useAuthState } from './authHooks'
 import { useUiState } from './uiHooks'
 
-export const useNotifyState = (
-  w3iProxy: Web3InboxProxy,
-  proxyReady: boolean,
-) => {
+export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) => {
   const [activeSubscriptions, setActiveSubscriptions] = useState<
     NotifyClientTypes.NotifySubscription[]
   >([])

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -25,8 +25,8 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     activeSubscriptions,
     refreshNotifyState,
     registerMessage: notifyRegisterMessage,
-    registeredKey: notifyRegisteredKey
-  } = useNotifyState(w3iProxy, isW3iProxyReady, dappOrigin)
+    registeredKey: notifyRegisteredKey,
+  } = useNotifyState(w3iProxy, isW3iProxyReady)
 
   return (
     <W3iContext.Provider
@@ -49,7 +49,7 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
         notifyClientProxy: notifyClient,
         sentInvites: [],
         threads: [],
-        invites: []
+        invites: [],
       }}
     >
       {children}

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -25,7 +25,7 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     activeSubscriptions,
     refreshNotifyState,
     registerMessage: notifyRegisterMessage,
-    registeredKey: notifyRegisteredKey,
+    registeredKey: notifyRegisteredKey
   } = useNotifyState(w3iProxy, isW3iProxyReady)
 
   return (
@@ -49,7 +49,7 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
         notifyClientProxy: notifyClient,
         sentInvites: [],
         threads: [],
-        invites: [],
+        invites: []
       }}
     >
       {children}

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -11,13 +11,13 @@ const useNotifyProjects = () => {
       const explorerApiBaseUrl: string = import.meta.env.VITE_EXPLORER_API_URL
       const projectId: string = import.meta.env.VITE_PROJECT_ID
 
-      const explorerUrl = `${explorerApiBaseUrl}/w3i/v1/projects?projectId=${projectId}&is_verified=${
+      const explorerUrl = filterAppDomain? `${explorerApiBaseUrl}/w3i/v1/notify-config?projectId=${projectId}&appDomain=${filterAppDomain}` : `${explorerApiBaseUrl}/w3i/v1/projects?projectId=${projectId}&is_verified=${
         isDevModeEnabled ? 'false' : 'true'
       }`
       const allProjectsRawRes = await fetch(explorerUrl)
-      const allNotifyProjectsRes = await allProjectsRawRes.json()
+      const allNotifyProjectsRes =  await allProjectsRawRes.json()
 
-      const notifyProjects: Omit<INotifyProject, 'app'>[] = Object.values(
+      const notifyProjects: Omit<INotifyProject, 'app'>[] = filterAppDomain? [allNotifyProjectsRes.data] : Object.values(
         allNotifyProjectsRes.projects
       )
       const notifyApps: INotifyApp[] = notifyProjects.map(
@@ -41,11 +41,8 @@ const useNotifyProjects = () => {
       setProjects(notifyApps)
     }
     fetchNotifyProjects()
-  }, [isDevModeEnabled, setProjects])
+  }, [isDevModeEnabled, setProjects, filterAppDomain])
 
-  if (filterAppDomain) {
-    return projects.filter(project => new URL(project.url).host === filterAppDomain)
-  }
 
   return projects
 }

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -43,8 +43,8 @@ const useNotifyProjects = () => {
     fetchNotifyProjects()
   }, [isDevModeEnabled, setProjects])
 
-  if(filterAppDomain) {
-    return projects.filter(project => new URL(project.url).host === filterAppDomain);
+  if (filterAppDomain) {
+    return projects.filter(project => new URL(project.url).host === filterAppDomain)
   }
 
   return projects

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -4,7 +4,7 @@ import type { INotifyApp, INotifyProject } from '../types'
 
 const useNotifyProjects = () => {
   const [projects, setProjects] = useState<INotifyApp[]>([])
-  const { isDevModeEnabled } = useContext(SettingsContext)
+  const { isDevModeEnabled, filterAppDomain } = useContext(SettingsContext)
 
   useEffect(() => {
     const fetchNotifyProjects = async () => {
@@ -42,6 +42,10 @@ const useNotifyProjects = () => {
     }
     fetchNotifyProjects()
   }, [isDevModeEnabled, setProjects])
+
+  if(filterAppDomain) {
+    return projects.filter(project => new URL(project.url).host === filterAppDomain);
+  }
 
   return projects
 }


### PR DESCRIPTION
# Description

Allow setting an app domain to filter by in the notification settings

Since we can't filter server side, this performs filtering client side via app domain (not project id) [EXACT MATCH]

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves #273 

# Examples/Screenshots (Optional)

| Description       | Image        |
| ------------ | ------------ |
| New Setting | ![image](https://github.com/WalletConnect/web3inbox/assets/61278030/fcc3f1d2-ae50-44f8-bccf-561f36516702) |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
