### PR TITLE
chore: return show notification function

### DIFF
--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -26,7 +26,7 @@ export const Modals = () => {
 
   const notificationsEnabled = useNotificationPermissionState()
 
-  const explicitlyDeniedOnDesktop = !isMobile() && Notification?.permission === 'denied'
+  const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
 
   const shouldShowNotificationModal = useMemo(
     () =>

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -12,6 +12,7 @@ import PwaModal from './components/utils/PwaModal'
 import { useNotificationPermissionState } from './utils/hooks/notificationHooks'
 import NotificationPwaModal from './components/utils/NotificationPwaModal'
 import { isMobile } from './utils/ui'
+import { notificationsEnabledInBrowser } from './utils/notifications'
 
 export const Modals = () => {
   const {
@@ -30,7 +31,7 @@ export const Modals = () => {
 
   const shouldShowNotificationModal = useMemo(
     () =>
-      Boolean(Notification) &&
+      notificationsEnabledInBrowser() &&
       !explicitlyDeniedOnDesktop &&
       !isMobileButNotInstalledOnHomescreen() &&
       !notificationsEnabled &&

--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -20,7 +20,7 @@ import { useNotificationPermissionState } from '../../../utils/hooks/notificatio
 import Input from '../../general/Input'
 
 const getHelperTooltip = () => {
-  switch (Notification?.permission) {
+  switch (window.Notification?.permission) {
     case 'denied':
       return 'You have explicitly disabled notifications. Please enable them via your browser or system settings'
     case 'granted':

--- a/src/components/utils/NotificationPwaModal/index.tsx
+++ b/src/components/utils/NotificationPwaModal/index.tsx
@@ -24,7 +24,7 @@ export const NotificationPwaModal: React.FC = () => {
     }
   }
 
-  const explicitlyDeniedPermissionForNotifications = Notification?.permission === 'denied'
+  const explicitlyDeniedPermissionForNotifications = window.Notification?.permission === 'denied'
 
   return (
     <Modal onToggleModal={pwaModalService.toggleModal}>

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -46,7 +46,7 @@ onBackgroundMessage(messaging, async ev => {
 
   const m = await decryptMessage({ encoded, symkey, topic })
 
-  self.registration.showNotification(m.title, {
+  return self.registration.showNotification(m.title, {
     icon: m.icon,
     body: m.body
   })

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -82,14 +82,14 @@ export const requireNotifyPermission = async () => {
 
   // No need to explicitly check for Notifications here since
   // the above check ensures it exists
-  switch (Notification.permission) {
+  switch (Notification?.permission) {
     case 'granted':
       return true
     case 'denied':
       console.error('User denied permissions')
       return false
     default:
-      return (await Notification.requestPermission()) === 'granted'
+      return (await Notification?.requestPermission()) === 'granted'
   }
 }
 

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -65,7 +65,7 @@ export const notificationsEnabledInBrowser = () => {
 
 export const userEnabledNotification = () => {
   if (notificationsEnabledInBrowser()) {
-    return Notification?.permission === 'granted'
+    return window.Notification?.permission === 'granted'
   }
   return false
 }
@@ -82,14 +82,14 @@ export const requireNotifyPermission = async () => {
 
   // No need to explicitly check for Notifications here since
   // the above check ensures it exists
-  switch (Notification?.permission) {
+  switch (window.Notification?.permission) {
     case 'granted':
       return true
     case 'denied':
       console.error('User denied permissions')
       return false
     default:
-      return (await Notification?.requestPermission()) === 'granted'
+      return (await window.Notification?.requestPermission()) === 'granted'
   }
 }
 

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -75,7 +75,7 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     }
 
     if (notificationsEnabledInBrowser()) {
-      await Notification.requestPermission()
+      await Notification?.requestPermission()
 
       await registerWithEcho(this.notifyClient)
     }

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -75,7 +75,7 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     }
 
     if (notificationsEnabledInBrowser()) {
-      await Notification?.requestPermission()
+      await window.Notification?.requestPermission()
 
       await registerWithEcho(this.notifyClient)
     }


### PR DESCRIPTION
# Description
**TL;DR: There's a race condition that causes the push notifications to be considered "silent push messages" which are flagged by the browser/OS as suspicious. Causing odd messages before every PN on desktop ("This site has been upgraded in the background") and lack of reliability on iOS. This should fix it.**

According to the sources below, not awaiting the `showNotification` and technically firing it after the listener resolves is a red flag for the browser/OS. 

- [StackOverflow, Chrome PNs causing odd messages "Site has been upgraded in the background"](https://stackoverflow.com/questions/31108699/chrome-push-notification-this-site-has-been-updated-in-the-background)
- [web.dev, handling push notifications](https://web.dev/articles/push-notifications-handling-messages#:~:text=Calling%20self.,the%20notification%20has%20been%20displayed.)
- [TruePush, iOS does not support silent web push messages](https://www.truepush.com/blog/ios-pwa-push-notifications/)
^ The means that a notification has to be shown to every `push` event. If the registration's `showMessage` is fired after that is resolved, it is considered a silent message. Red flag for iOS

**This also fixes issue causing white screens, by guarding every single reference to `Notification` even when it logically wouldn't be accessed.  Due to "Variable Not Found Errors".**

[Slack thread about Notification variable causing white screens](https://walletconnect.slack.com/archives/C0665P2HYM9/p1700230743240109?thread_ts=1700230313.710669&cid=C0665P2HYM9)
# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
