### PR TITLE
fix: redirect when there are no subs

### DIFF
--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -56,12 +56,6 @@ const AppSelector: React.FC = () => {
     filterApps(search)
   }, [search, filterApps, activeSubscriptions])
 
-  useEffect(() => {
-    if (activeSubscriptions.length === 0) {
-      nav('/notifications/new-app')
-    }
-  }, [nav, activeSubscriptions])
-
   return (
     <div className="AppSelector">
       {isMobile && pathname.endsWith('/notifications') ? (

--- a/src/components/notifications/NotificationsLayout/index.tsx
+++ b/src/components/notifications/NotificationsLayout/index.tsx
@@ -4,13 +4,15 @@ import AppSelector from '../AppSelector'
 import { AnimatePresence } from 'framer-motion'
 import { motion } from 'framer-motion'
 import W3iContext from '../../../contexts/W3iContext/context'
+import { useIsMobile } from '../../../utils/hooks'
 
 const NotificationsLayout: React.FC = () => {
   const { activeSubscriptions } = useContext(W3iContext)
   const { pathname } = useLocation()
+  const isMobile = useIsMobile()
 
   if (pathname === '/notifications') {
-    if (!activeSubscriptions.length) {
+    if (isMobile && !activeSubscriptions.length) {
       return <Navigate to="/notifications/new-app" />
     }
   }

--- a/src/components/notifications/NotificationsLayout/index.tsx
+++ b/src/components/notifications/NotificationsLayout/index.tsx
@@ -4,15 +4,13 @@ import AppSelector from '../AppSelector'
 import { AnimatePresence } from 'framer-motion'
 import { motion } from 'framer-motion'
 import W3iContext from '../../../contexts/W3iContext/context'
-import { useIsMobile } from '../../../utils/hooks'
 
 const NotificationsLayout: React.FC = () => {
   const { activeSubscriptions } = useContext(W3iContext)
   const { pathname } = useLocation()
-  const isMobile = useIsMobile()
 
   if (pathname === '/notifications') {
-    if (isMobile && !activeSubscriptions.length) {
+    if (!activeSubscriptions.length) {
       return <Navigate to="/notifications/new-app" />
     }
   }

--- a/src/components/notifications/NotificationsLayout/index.tsx
+++ b/src/components/notifications/NotificationsLayout/index.tsx
@@ -1,14 +1,18 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useContext } from 'react'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import AppSelector from '../AppSelector'
 import { AnimatePresence } from 'framer-motion'
 import { motion } from 'framer-motion'
+import W3iContext from '../../../contexts/W3iContext/context'
 
 const NotificationsLayout: React.FC = () => {
+  const { activeSubscriptions } = useContext(W3iContext)
   const { pathname } = useLocation()
 
   if (pathname === '/notifications') {
-    return <Navigate to="/notifications/new-app" />
+    if (!activeSubscriptions.length) {
+      return <Navigate to="/notifications/new-app" />
+    }
   }
 
   return (

--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -78,7 +78,7 @@ const NotificationsSettings: React.FC = () => {
           >
             <Input
               value={filterAppDomain}
-	      placeholder="app.example.com"
+              placeholder="app.example.com"
               onChange={ev => updateSettings({ filterAppDomain: ev.target.value })}
             />
           </SettingsItem>
@@ -102,7 +102,10 @@ const NotificationsSettings: React.FC = () => {
             </SettingsItem>
           </div>
 
-          <div className="NotificationsSettings__debug" style={{opacity: isDevModeEnabled? 1 : 0}}>
+          <div
+            className="NotificationsSettings__debug"
+            style={{ opacity: isDevModeEnabled ? 1 : 0 }}
+          >
             {tokenEntries.map(([clientId, fcmToken], idx) => {
               return (
                 <div className="NotificationsSettings__debug-row">

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -3,3 +3,10 @@ export const SERVICE_WORKER_ACTIONS = {
   SET_SUBS_SYMKEYS: 'SET_SUBS_SYMKEYS',
   REGISTER_WITH_ECHO: 'REGISTER_WITH_ECHO'
 }
+
+export const EXPLORER_API_BASE_URL: string = import.meta.env.VITE_EXPLORER_API_URL
+
+export const EXPLORER_ENDPOINTS = {
+  projects: '/w3i/v1/projects',
+  notifyConfig: '/w3i/v1/notify-config'
+}

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -11,15 +11,17 @@ const useNotifyProjects = () => {
       const explorerApiBaseUrl: string = import.meta.env.VITE_EXPLORER_API_URL
       const projectId: string = import.meta.env.VITE_PROJECT_ID
 
-      const explorerUrl = filterAppDomain? `${explorerApiBaseUrl}/w3i/v1/notify-config?projectId=${projectId}&appDomain=${filterAppDomain}` : `${explorerApiBaseUrl}/w3i/v1/projects?projectId=${projectId}&is_verified=${
-        isDevModeEnabled ? 'false' : 'true'
-      }`
+      const explorerUrl = filterAppDomain
+        ? `${explorerApiBaseUrl}/w3i/v1/notify-config?projectId=${projectId}&appDomain=${filterAppDomain}`
+        : `${explorerApiBaseUrl}/w3i/v1/projects?projectId=${projectId}&is_verified=${
+            isDevModeEnabled ? 'false' : 'true'
+          }`
       const allProjectsRawRes = await fetch(explorerUrl)
-      const allNotifyProjectsRes =  await allProjectsRawRes.json()
+      const allNotifyProjectsRes = await allProjectsRawRes.json()
 
-      const notifyProjects: Omit<INotifyProject, 'app'>[] = filterAppDomain? [allNotifyProjectsRes.data] : Object.values(
-        allNotifyProjectsRes.projects
-      )
+      const notifyProjects: Omit<INotifyProject, 'app'>[] = filterAppDomain
+        ? [allNotifyProjectsRes.data]
+        : Object.values(allNotifyProjectsRes.projects)
       const notifyApps: INotifyApp[] = notifyProjects.map(
         ({
           id,
@@ -44,7 +46,6 @@ const useNotifyProjects = () => {
     }
     fetchNotifyProjects()
   }, [isDevModeEnabled, setProjects, filterAppDomain])
-
 
   return projects
 }

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -11,16 +11,18 @@ const useNotifyProjects = () => {
     const fetchNotifyProjects = async () => {
       const projectId: string = import.meta.env.VITE_PROJECT_ID
 
-      const explorerUrl = new URL(filterAppDomain? EXPLORER_ENDPOINTS.notifyConfig : EXPLORER_ENDPOINTS.projects, EXPLORER_API_BASE_URL);
+      const explorerUrl = new URL(
+        filterAppDomain ? EXPLORER_ENDPOINTS.notifyConfig : EXPLORER_ENDPOINTS.projects,
+        EXPLORER_API_BASE_URL
+      )
       explorerUrl.searchParams.set('projectId', projectId)
 
-      if(filterAppDomain) {
+      if (filterAppDomain) {
         explorerUrl.searchParams.set('appDomain', filterAppDomain)
-      }
-      else {
+      } else {
         explorerUrl.searchParams.set('is_verified', isDevModeEnabled ? 'false' : 'true')
       }
-      
+
       const allProjectsRawRes = await fetch(explorerUrl)
       const allNotifyProjectsRes = await allProjectsRawRes.json()
 

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from 'react'
 import SettingsContext from '../../contexts/SettingsContext/context'
 import type { INotifyApp, INotifyProject } from '../types'
+import { EXPLORER_API_BASE_URL, EXPLORER_ENDPOINTS } from '../constants'
 
 const useNotifyProjects = () => {
   const [projects, setProjects] = useState<INotifyApp[]>([])
@@ -8,14 +9,18 @@ const useNotifyProjects = () => {
 
   useEffect(() => {
     const fetchNotifyProjects = async () => {
-      const explorerApiBaseUrl: string = import.meta.env.VITE_EXPLORER_API_URL
       const projectId: string = import.meta.env.VITE_PROJECT_ID
 
-      const explorerUrl = filterAppDomain
-        ? `${explorerApiBaseUrl}/w3i/v1/notify-config?projectId=${projectId}&appDomain=${filterAppDomain}`
-        : `${explorerApiBaseUrl}/w3i/v1/projects?projectId=${projectId}&is_verified=${
-            isDevModeEnabled ? 'false' : 'true'
-          }`
+      const explorerUrl = new URL(filterAppDomain? EXPLORER_ENDPOINTS.notifyConfig : EXPLORER_ENDPOINTS.projects, EXPLORER_API_BASE_URL);
+      explorerUrl.searchParams.set('projectId', projectId)
+
+      if(filterAppDomain) {
+        explorerUrl.searchParams.set('appDomain', filterAppDomain)
+      }
+      else {
+        explorerUrl.searchParams.set('is_verified', isDevModeEnabled ? 'false' : 'true')
+      }
+      
       const allProjectsRawRes = await fetch(explorerUrl)
       const allNotifyProjectsRes = await allProjectsRawRes.json()
 

--- a/src/utils/idb.ts
+++ b/src/utils/idb.ts
@@ -20,7 +20,7 @@ const STORE_NAMES = [SYMKEY_OBJ_STORE, ECHO_REGISTRATION_STORE]
  * This involves changing store names above, adding stores, or changing the schema
  * in any other way.
  */
-const DATABASE_VERSION = 5;
+const DATABASE_VERSION = 5
 
 // Returns getter and setter for idb properties as it used as a key value store
 export const getIndexedDbStore = async (


### PR DESCRIPTION
# Description
- Run prettier on unformatted files
- Fix a bug in `NotificationsLayout` where user was being redirected to `/new-app` even when they had existing subscriptions (on mobile), which is not the intended experience
- This fixes it to intended UX:
    - On desktop, always go to `/notifications/new-app` when on `/notifications` (as we have the screen space to display the selector an the explorer
    - On mobile, only go `/notifications/new-app` if there are no subscriptions

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

