### PR TITLE
refactor: update show more logic

### DIFF
--- a/src/components/notifications/AppNotifications/AppNotificationItem.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationItem.tsx
@@ -1,5 +1,5 @@
 import { useFormattedTime } from '../../../utils/hooks'
-import { createRef, useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import cn from 'classnames'
 import CircleIcon from '../../general/Icon/CircleIcon'
 import { LazyMotion, domMax } from 'framer-motion'

--- a/src/components/notifications/AppNotifications/AppNotificationItem.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationItem.tsx
@@ -1,10 +1,12 @@
 import { useFormattedTime } from '../../../utils/hooks'
-import { useEffect, useRef, useState } from 'react'
+import { createRef, useCallback, useEffect, useRef, useState } from 'react'
 import cn from 'classnames'
 import CircleIcon from '../../general/Icon/CircleIcon'
 import { LazyMotion, domMax } from 'framer-motion'
 import Text from '../../general/Text'
 import './AppNotifications.scss'
+
+const MAX_BODY_LENGTH = 180
 
 export interface IAppNotification {
   id: string
@@ -23,20 +25,23 @@ interface IAppNotificationProps {
 
 const AppNotificationItem: React.FC<IAppNotificationProps> = ({ notification, appLogo }) => {
   const formattedTime = useFormattedTime(notification.timestamp)
-  const [textClamped, setTextClamped] = useState<boolean>(false)
-  const [show, setShow] = useState<boolean>(false)
-
-  const messageRef = useRef<HTMLSpanElement | null>(null)
+  const [textClamped, setTextClamped] = useState<boolean>(
+    notification.message.length > MAX_BODY_LENGTH
+  )
+  const [showMore, setShowMore] = useState<boolean>(false)
 
   useEffect(() => {
-    if (messageRef.current) {
-      setTextClamped(messageRef.current.scrollHeight > messageRef.current.clientHeight)
-    }
-  }, [])
+    setTextClamped(notification.message.length > MAX_BODY_LENGTH)
+  }, [notification.message])
 
   const handleToggleDescription = () => {
-    setShow(prevState => !prevState)
+    setShowMore(prevState => !prevState)
   }
+
+  const body =
+    textClamped && !showMore
+      ? notification.message.slice(0, MAX_BODY_LENGTH) + '...'
+      : notification.message
 
   return (
     <LazyMotion features={domMax}>
@@ -65,18 +70,17 @@ const AppNotificationItem: React.FC<IAppNotificationProps> = ({ notification, ap
             </div>
           </div>
           <Text
-            ref={messageRef}
-            className={cn('AppNotifications__item__message', show ? 'show_more' : '')}
+            className={cn('AppNotifications__item__message', showMore ? 'show_more' : '')}
             variant="small-400"
           >
-            {notification.message}
+            {body}
           </Text>
           {textClamped && (
             <button
               onClick={handleToggleDescription}
               className="AppNotifications__item__show_button"
             >
-              <Text variant="small-400">{show ? 'Show less' : 'Show more'}</Text>
+              <Text variant="small-400">{showMore ? 'Show less' : 'Show more'}</Text>
             </button>
           )}
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,10 @@ textarea {
   box-sizing: border-box;
 }
 
+*::selection {
+  background: rgba(0, 0, 0, 0.1);
+}
+
 img,
 picture,
 svg,


### PR DESCRIPTION
# Description

Refactored "show more/less" logic since the previous solution isn't quite useful when we change the screen sizes. It doesn't respect the content. Instead of using `line-clamp` and calculating the text size, this is a better solution so it doesn't require us to calculate element heights.

Another solution would be to listen screen size change and update the visibility value but this is not performant way to implement it. Once we have lots of notifications in a page, this might bring perfomance issues in the screen. Let's just keep is as simple as possible.

# Type of change

Please put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
