### PR TITLE
refactor: dapp preferences modal loading state & modals outside click handlers

### DIFF
--- a/src/components/general/Button/Button.scss
+++ b/src/components/general/Button/Button.scss
@@ -10,6 +10,7 @@
   box-shadow: inset 0 0 0 1px var(--light-overlay-010);
   border: none;
   transition: opacity 300ms ease;
+  height: 2.5rem;
 
   &:hover {
     opacity: 0.8;

--- a/src/components/general/Modal/Modal.tsx
+++ b/src/components/general/Modal/Modal.tsx
@@ -7,14 +7,14 @@ import { useOnClickOutside, useResizeObserver } from '@/utils/hooks'
 import './Modal.scss'
 
 interface IModalProps {
-  onToggleModal: () => void
+  onCloseModal: () => void
   children: React.ReactNode
   width?: string
   height?: string
 }
-export const Modal: React.FC<IModalProps> = ({ children, onToggleModal, width, height }) => {
+export const Modal: React.FC<IModalProps> = ({ children, onCloseModal, width, height }) => {
   const ref = useRef<HTMLDivElement>(null)
-  useOnClickOutside(ref, onToggleModal)
+  useOnClickOutside(ref, onCloseModal)
 
   const onResize = useCallback((target: HTMLDivElement) => {
     if (ref.current) {

--- a/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
@@ -63,6 +63,7 @@ export const PreferencesModal: React.FC = () => {
       } catch (error) {
         console.error(error)
         showErrorMessageToast('Failed to update preferences')
+        setLoading(false)
       }
     }
   }, [preferencesModalAppId, notifyClientProxy, scopes])

--- a/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/PreferencesModal/index.tsx
@@ -5,6 +5,7 @@ import type { NotifyClientTypes } from '@walletconnect/notify-client'
 import Button from '@/components/general/Button'
 import CrossIcon from '@/components/general/Icon/CrossIcon'
 import { Modal } from '@/components/general/Modal/Modal'
+import Spinner from '@/components/general/Spinner'
 import Text from '@/components/general/Text'
 import Toggle from '@/components/general/Toggle'
 import SettingsContext from '@/contexts/SettingsContext/context'
@@ -17,9 +18,9 @@ import './PreferencesModal.scss'
 
 export const PreferencesModal: React.FC = () => {
   const { activeSubscriptions, notifyClientProxy } = useContext(W3iContext)
-  const { mode } = useContext(SettingsContext)
   const { preferencesModalAppId } = useModals()
   const [scopes, setScopes] = useState<NotifyClientTypes.NotifySubscription['scope']>({})
+  const [loading, setLoading] = useState(false)
 
   // Reduces the scopes mapping to only an array of enabled scopes
   const getEnabledScopes = (scopesMap: NotifyClientTypes.NotifySubscription['scope']) => {
@@ -43,6 +44,7 @@ export const PreferencesModal: React.FC = () => {
   }, [preferencesModalAppId, setScopes, activeSubscriptions])
 
   const handleUpdatePreferences = useCallback(async () => {
+    setLoading(true)
     if (preferencesModalAppId) {
       const topic = preferencesModalAppId
 
@@ -50,6 +52,7 @@ export const PreferencesModal: React.FC = () => {
         notifyClientProxy?.observeOne('notify_update', {
           next: () => {
             preferencesModalService.closeModal()
+            setLoading(false)
             showSuccessMessageToast('Preferences updated successfully')
           }
         })
@@ -65,7 +68,7 @@ export const PreferencesModal: React.FC = () => {
   }, [preferencesModalAppId, notifyClientProxy, scopes])
 
   return (
-    <Modal onToggleModal={preferencesModalService.toggleModal}>
+    <Modal onCloseModal={preferencesModalService.closeModal}>
       <div className="PreferencesModal">
         <div className="PreferencesModal__header">
           <Text variant="paragraph-600">Preferences</Text>
@@ -109,8 +112,12 @@ export const PreferencesModal: React.FC = () => {
         </div>
         <div className="PreferencesModal__overflow-gradient" />
         <div className="PreferencesModal__action">
-          <Button className="PreferencesModal__action__btn" onClick={handleUpdatePreferences}>
-            Update
+          <Button
+            disabled={loading}
+            className="PreferencesModal__action__btn"
+            onClick={handleUpdatePreferences}
+          >
+            {loading ? <Spinner /> : 'Update'}
           </Button>
         </div>
       </div>

--- a/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
@@ -53,7 +53,7 @@ export const UnsubscribeModal: React.FC = () => {
   }
 
   return (
-    <Modal onToggleModal={unsubscribeModalService.toggleModal}>
+    <Modal onCloseModal={unsubscribeModalService.closeModal}>
       <div className="UnsubscribeModal">
         <div className="UnsubscribeModal__header">
           <Text variant="paragraph-600">Unsubscribe</Text>

--- a/src/components/settings/ContactsModal/index.tsx
+++ b/src/components/settings/ContactsModal/index.tsx
@@ -47,7 +47,7 @@ const ContactsModal: React.FC<ContactsModalProps> = ({
   )
 
   return (
-    <Modal onToggleModal={contactsModalService.toggleModal}>
+    <Modal onCloseModal={contactsModalService.closeModal}>
       <div className="ContactsModal">
         <div className="ContactsModal__header">
           <h2>{capitalize(status)} contacts</h2>

--- a/src/components/utils/NotificationPwaModal/index.tsx
+++ b/src/components/utils/NotificationPwaModal/index.tsx
@@ -29,7 +29,7 @@ export const NotificationPwaModal: React.FC = () => {
   const explicitlyDeniedPermissionForNotifications = window.Notification?.permission === 'denied'
 
   return (
-    <Modal onToggleModal={pwaModalService.toggleModal}>
+    <Modal onCloseModal={pwaModalService.closeModal}>
       <div className="NotificationPwaModal">
         <div className="NotificationPwaModal__background">
           <img src={BackgroundImage} />

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -48,7 +48,7 @@ export const getPlatformInstallText = () => {
 
 export const PwaModal: React.FC = () => {
   return (
-    <Modal onToggleModal={pwaModalService.toggleModal}>
+    <Modal onCloseModal={pwaModalService.closeModal}>
       <div className="PwaModal">
         <div className="PwaModal__background">
           <img src={BackgroundImage} />

--- a/src/pages/Login/SignatureModal/index.tsx
+++ b/src/pages/Login/SignatureModal/index.tsx
@@ -51,7 +51,7 @@ export const SignatureModal: React.FC<{
   }, [message, sender])
 
   return (
-    <Modal onToggleModal={signatureModalService.toggleModal}>
+    <Modal onCloseModal={signatureModalService.closeModal}>
       <div className="SignatureModal">
         <div className="SignatureModal__header">
           <div onClick={() => disconnect()} className="SignatureModal__exit">


### PR DESCRIPTION
# Description

We currently lack a loading state for the save button in our dApp preferences. This proposed change aims to enhance user feedback by incorporating this feature. Additionally, our modals require improved handling of outside clicks. Rather than using `toggleModal`, it would be better to call `closeModal`. This change will address the issue of multiple clicks on the overlay, enhancing overall functionality.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Examples/Screenshots (Optional)

https://github.com/WalletConnect/web3inbox/assets/19428358/d6b651f0-9ad3-4c6c-8d50-a5b75d676479

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

# Additional Information (Optional)

Fixes: https://github.com/WalletConnect/web3inbox/issues/282
