### PR TITLE
fix: discover apps

### DIFF
--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -112,10 +112,10 @@ const AppSelector: React.FC = () => {
                       <img
                         className="AppSelector__link-apps"
                         src={AllAppsIcon}
-                        alt="Discover all apps logo"
+                        alt="Discover apps logo"
                         loading="lazy"
                       />
-                      <Text variant="small-500">Discover all apps</Text>
+                      <Text variant="small-500">Discover apps</Text>
                     </div>
                   </div>
                 </NavLink>


### PR DESCRIPTION
Change "Discover all apps" to "Discover apps" because we are only showing featured apps, not all apps. [Context](https://walletconnect.slack.com/archives/C044SKFKELR/p1701790341053199).