### PR TITLE
refactor: update app card styles

### DIFF
--- a/src/components/notifications/AppExplorer/AppCard/AppCard.scss
+++ b/src/components/notifications/AppExplorer/AppCard/AppCard.scss
@@ -29,13 +29,12 @@
      */
     z-index: 0;
     position: absolute;
-    border-radius: 1.875em;
     background-repeat: no-repeat;
-    background-position: -60px -60px;
-    background-size: 256px;
-    opacity: 50%;
-    filter: blur(120px);
+    background-position: -50px -50px;
+    background-size: 80%;
     overflow: hidden;
+    filter: blur(32px) saturate(1.2);
+    opacity: 0.15;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
# Description

The current styling solution for the app cards causing some performance issues. The `filter` or `backdrop filter` is one of the most expensive stylings and when we put more value on the `blur` filter. It'll dramatically drop the performance. We can see the effect of this in the Discover page on Safari. While we scroll, the apps are rendered to the screen with a lag.

This PR includes a refactor to optimize the background image styles of the App card. 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/355
