### PR TITLE
fix: use interval to load state incrementally

### DIFF
--- a/src/components/notifications/AppSelector/AppSelector.scss
+++ b/src/components/notifications/AppSelector/AppSelector.scss
@@ -213,12 +213,22 @@
       }
     }
 
+    @keyframes slideIn {
+      0% {
+        transform: translateX(-100%);
+      }
+      100% {
+        transform: translateX(0);
+      }
+    }
+
     &-item {
       padding: 0.75rem 1rem 0.75rem 0.75rem;
       border-radius: 1em;
       position: relative;
-      transition: background-color 0.1s linear;
+      transition: background-color 0.2s linear;
       will-change: background-color;
+      animation: slideIn 0.5s ease-in;
 
       @media only screen and (max-width: 700px) {
         border-radius: 0px;

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -168,8 +168,7 @@ const AppSelector: React.FC = () => {
                   </AnimatePresence>
                 )
               })}
-            {loading || !subscriptionsFinishedLoading
-              ? Array(3)
+            {loading || !subscriptionsFinishedLoading? Array(3)
                   .fill(<LinkItemSkeleton />)
                   .map(x => x)
               : null}

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -32,7 +32,7 @@ const AppSelector: React.FC = () => {
   const isMobile = useIsMobile()
   const [filteredApps, setFilteredApps] = useState<NotifyClientTypes.NotifySubscription[]>([])
   const [loading, setLoading] = useState(true)
-  const { activeSubscriptions } = useContext(W3iContext)
+  const { activeSubscriptions, watchSubscriptionsComplete: subscriptionsFinishedLoading } = useContext(W3iContext)
   const { projects } = useNotifyProjects()
 
   const empty = !loading && filteredApps.length === 0
@@ -131,11 +131,6 @@ const AppSelector: React.FC = () => {
         <div className="AppSelector__wrapper">
           {!empty ? <Label color="main">Subscribed</Label> : null}
           <ul className="AppSelector__list">
-            {loading
-              ? Array(3)
-                  .fill(<LinkItemSkeleton />)
-                  .map(x => x)
-              : null}
             {!loading &&
               filteredApps?.map(app => {
                 return (
@@ -173,6 +168,11 @@ const AppSelector: React.FC = () => {
                   </AnimatePresence>
                 )
               })}
+            {loading || !subscriptionsFinishedLoading
+              ? Array(3)
+                  .fill(<LinkItemSkeleton />)
+                  .map(x => x)
+              : null}
           </ul>
         </div>
       </div>

--- a/src/contexts/W3iContext/context.ts
+++ b/src/contexts/W3iContext/context.ts
@@ -34,6 +34,7 @@ interface W3iContextState {
   dappName: string
   dappIcon: string
   dappNotificationDescription: string
+  watchSubscriptionsComplete: boolean,
   // This is only kept to allow old components to build
   chatClientProxy: W3iChatClient | null
 }
@@ -56,7 +57,8 @@ const W3iContext = createContext<W3iContextState>({
   dappIcon: '',
   dappNotificationDescription: '',
   dappName: '',
-  chatClientProxy: null
+  chatClientProxy: null,
+  watchSubscriptionsComplete: false
 })
 
 export default W3iContext

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -127,7 +127,10 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     })
 
     const notifySubsChanged = notifyClient.observe('notify_subscriptions_changed', {
-      next: refreshNotifyState
+      next: () => {
+	setWatchSubscriptionsComplete(true)
+        refreshNotifyState()
+      }
     })
 
     const syncUpdateSub = notifyClient.observe('sync_update', {

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -24,6 +24,8 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
 
   const [notifyClient, setNotifyClient] = useState<W3iNotifyClient | null>(null)
 
+  const [watchSubscriptionsComplete, setWatchSubscriptionsComplete] = useState(false);
+
   useEffect(() => {
     if (proxyReady) {
       setNotifyClient(w3iProxy.notify)
@@ -44,12 +46,18 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     })
   }, [notifyClient, userPubkey, proxyReady])
 
+  // it takes time for handshake (watch subscriptions) to complete
+  // load in progress state using interval until it is
   useEffect(() => {
+    if(watchSubscriptionsComplete) {
+      return noop;
+    }
+
     // Account for sync init
-    const timeoutId = setTimeout(() => refreshNotifyState(), 100)
+    const timeoutId = setInterval(() => refreshNotifyState(), 500)
 
     return () => clearTimeout(timeoutId)
-  }, [refreshNotifyState])
+  }, [refreshNotifyState, watchSubscriptionsComplete])
 
   const handleRegistration = useCallback(
     async (key: string) => {
@@ -137,5 +145,5 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     }
   }, [notifyClient, refreshNotifyState])
 
-  return { activeSubscriptions, registeredKey, registerMessage, notifyClient, refreshNotifyState }
+  return { activeSubscriptions, registeredKey, registerMessage, notifyClient, refreshNotifyState, watchSubscriptionsComplete }
 }

--- a/src/contexts/W3iContext/index.tsx
+++ b/src/contexts/W3iContext/index.tsx
@@ -27,7 +27,8 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
     activeSubscriptions,
     refreshNotifyState,
     registerMessage: notifyRegisterMessage,
-    registeredKey: notifyRegisteredKey
+    registeredKey: notifyRegisteredKey,
+    watchSubscriptionsComplete
   } = useNotifyState(w3iProxy, isW3iProxyReady)
 
   return (
@@ -51,7 +52,8 @@ const W3iContextProvider: React.FC<W3iContextProviderProps> = ({ children }) => 
         notifyClientProxy: notifyClient,
         sentInvites: [],
         threads: [],
-        invites: []
+        invites: [],
+	watchSubscriptionsComplete
       }}
     >
       {children}


### PR DESCRIPTION
# Description

- changed the `setTimeout` to `setInterval` in the initial loading for `notifyHooks` state
- Show loading indicator while the interval is running
# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves #326 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
