### PR TITLE
refactor: revert the refresh notify state interval logic

### DIFF
--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -26,7 +26,7 @@ import './AppSelector.scss'
 
 const SUBSCRIPTION_LOADER_TIMEOUT = 3000
 
-const SkeletonItems = Array.from({length: 3}, (_,idx) => (<LinkItemSkeleton key={idx} />))
+const SkeletonItems = Array.from({ length: 3 }, (_, idx) => <LinkItemSkeleton key={idx} />)
 
 const AppSelector: React.FC = () => {
   const { pathname } = useLocation()
@@ -34,7 +34,8 @@ const AppSelector: React.FC = () => {
   const isMobile = useIsMobile()
   const [filteredApps, setFilteredApps] = useState<NotifyClientTypes.NotifySubscription[]>([])
   const [loading, setLoading] = useState(true)
-  const { activeSubscriptions, watchSubscriptionsComplete: subscriptionsFinishedLoading } = useContext(W3iContext)
+  const { activeSubscriptions, watchSubscriptionsComplete: subscriptionsFinishedLoading } =
+    useContext(W3iContext)
   const { projects } = useNotifyProjects()
 
   const empty = !loading && filteredApps.length === 0
@@ -170,7 +171,7 @@ const AppSelector: React.FC = () => {
                   </AnimatePresence>
                 )
               })}
-            {loading || !subscriptionsFinishedLoading? SkeletonItems : null}
+            {loading || !subscriptionsFinishedLoading ? SkeletonItems : null}
           </ul>
         </div>
       </div>

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -24,7 +24,7 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
 
   const [notifyClient, setNotifyClient] = useState<W3iNotifyClient | null>(null)
 
-  const [watchSubscriptionsComplete, setWatchSubscriptionsComplete] = useState(false);
+  const [watchSubscriptionsComplete, setWatchSubscriptionsComplete] = useState(false)
 
   useEffect(() => {
     if (proxyReady) {
@@ -49,18 +49,16 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
   // it takes time for handshake (watch subscriptions) to complete
   // load in progress state using interval until it is
   useEffect(() => {
+    if (watchSubscriptionsComplete) {
+      return noop
+    }
     // Account for sync init
     const intervalId = setInterval(() => {
-      if(notifyClient?.isInitialSubscriptionLoadComplete()) {
-        setWatchSubscriptionsComplete(true);
-	clearInterval(intervalId);
-        return;
-      }
       refreshNotifyState()
     }, 500)
 
     return () => clearInterval(intervalId)
-  }, [refreshNotifyState, notifyClient, setWatchSubscriptionsComplete])
+  }, [refreshNotifyState, watchSubscriptionsComplete])
 
   const handleRegistration = useCallback(
     async (key: string) => {
@@ -132,7 +130,7 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     const notifySubsChanged = notifyClient.observe('notify_subscriptions_changed', {
       next: () => {
         refreshNotifyState()
-	setWatchSubscriptionsComplete(true)
+        setWatchSubscriptionsComplete(true)
       }
     })
 
@@ -151,5 +149,12 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     }
   }, [notifyClient, refreshNotifyState, setWatchSubscriptionsComplete])
 
-  return { activeSubscriptions, registeredKey, registerMessage, notifyClient, refreshNotifyState, watchSubscriptionsComplete }
+  return {
+    activeSubscriptions,
+    registeredKey,
+    registerMessage,
+    notifyClient,
+    refreshNotifyState,
+    watchSubscriptionsComplete
+  }
 }


### PR DESCRIPTION
# Description

The code piece in [this useEffect](https://github.com/WalletConnect/web3inbox/blob/main/src/contexts/W3iContext/hooks/notifyHooks.ts#L54-L57)  is running before the notify handshake is done, this causes the same issue we have that the loading skeletons are unmounted before the handshake completed and as a result, creates the same bad UX issue.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional notes

Closes https://github.com/WalletConnect/web3inbox/issues/329