### PR TITLE
refactor: subscriptions mobile page and skeleton rendering logics

### DIFF
--- a/src/components/notifications/AppSelector/AppSelector.scss
+++ b/src/components/notifications/AppSelector/AppSelector.scss
@@ -28,6 +28,10 @@
     border: solid 1px var(--accent-color-1);
     padding: 0.5em 0.5em;
   }
+  &__empty__message {
+    color: var(--fg-color-2);
+    padding: 0.5rem 0.75rem;
+  }
 
   .App,
   .Input {

--- a/src/components/notifications/AppSelector/AppSelector.scss
+++ b/src/components/notifications/AppSelector/AppSelector.scss
@@ -45,7 +45,6 @@
     gap: 1.5rem;
 
     @media only screen and (max-width: 700px) {
-      margin-top: 0px;
       gap: 1.25rem;
       padding-bottom: 10%;
     }
@@ -59,9 +58,9 @@
     .Label {
       padding: 0px 0.75rem;
 
-      @media only screen and (max-width: 700px) {
-        padding: 0 1.25rem;
-      }
+      // @media only screen and (max-width: 700px) {
+      //   padding: 0 1.25rem;
+      // }
     }
   }
 
@@ -171,6 +170,11 @@
       position: relative;
       transition: background-color 0.1s linear;
       will-change: background-color;
+
+      @media only screen and (max-width: 700px) {
+        border-radius: 0px;
+        padding: 1rem 1.25rem;
+      }
 
       &:not(.NavLink-active):hover {
         @media (hover: hover) {

--- a/src/components/notifications/AppSelector/LinkItemSkeleton/LinkItemSkeleton.scss
+++ b/src/components/notifications/AppSelector/LinkItemSkeleton/LinkItemSkeleton.scss
@@ -1,8 +1,10 @@
 .AppSelector {
   &__link {
     &-item-skeleton {
+      width: 100%;
       display: flex;
       align-items: center;
+      justify-content: flex-start;
       gap: 0.75rem;
       height: 56px;
       padding: 0.75rem 1rem 0.75rem 0.75rem;
@@ -18,22 +20,16 @@
       &__icon {
         will-change: opacity;
         background: var(--shimmer-fg);
-        width: 0.75em;
-        height: 0.75em;
-
-        @media only screen and (min-width: 700px) {
-          border-radius: 50%;
-          padding: 0.5em;
-          width: 2em;
-          height: 2em;
-        }
+        min-width: 2rem;
+        min-height: 2rem;
+        border-radius: 50%;
       }
 
       &__description {
         will-change: opacity;
         background: var(--shimmer-fg);
         width: 50%;
-        height: 18px;
+        height: 1.125px;
       }
     }
   }

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -104,34 +104,24 @@ const AppSelector: React.FC = () => {
       <TargetTitle className="AppSelector__target-title" to="/notifications/new-app">
         <Text variant="large-700">Inbox</Text>
       </TargetTitle>
-      {isMobile && empty && !subscriptionsLoading ? (
-        <div className="AppSelector__empty__message">
-          <Text variant="small-500">You don't have any subscriptions yet</Text>
-        </div>
-      ) : null}
-
       <div className="AppSelector__lists">
         <div className="AppSelector__wrapper">
-          {!isMobile && (
-            <>
-              <Label color="main">Discover</Label>
-              <ul className="AppSelector__list">
-                <NavLink to={`/notifications/new-app`} end className="AppSelector__link-appsItem">
-                  <div className="AppSelector__notifications">
-                    <div className="AppSelector__notifications-apps">
-                      <img
-                        className="AppSelector__link-apps"
-                        src={AllAppsIcon}
-                        alt="Discover apps logo"
-                        loading="lazy"
-                      />
-                      <Text variant="small-500">Discover apps</Text>
-                    </div>
-                  </div>
-                </NavLink>
-              </ul>
-            </>
-          )}
+          <Label color="main">Discover</Label>
+          <ul className="AppSelector__list">
+            <NavLink to={`/notifications/new-app`} end className="AppSelector__link-appsItem">
+              <div className="AppSelector__notifications">
+                <div className="AppSelector__notifications-apps">
+                  <img
+                    className="AppSelector__link-apps"
+                    src={AllAppsIcon}
+                    alt="Discover apps logo"
+                    loading="lazy"
+                  />
+                  <Text variant="small-500">Discover apps</Text>
+                </div>
+              </div>
+            </NavLink>
+          </ul>
         </div>
         <div className="AppSelector__wrapper">
           {!empty || subscriptionsLoading ? <Label color="main">Subscribed</Label> : null}

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -173,7 +173,7 @@ const AppSelector: React.FC = () => {
                   </AnimatePresence>
                 )
               })}
-            {!subscriptionsLoading ? SkeletonItems : null}
+            {subscriptionsLoading ? SkeletonItems : null}
           </ul>
         </div>
       </div>

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -39,6 +39,7 @@ const AppSelector: React.FC = () => {
   const { projects } = useNotifyProjects()
 
   const empty = !loading && filteredApps.length === 0
+  const subscriptionsLoading = loading || !subscriptionsFinishedLoading
 
   const fetchApps = async (searchQuery: string) => {
     const newFilteredApps = [] as NotifyClientTypes.NotifySubscription[]
@@ -90,23 +91,24 @@ const AppSelector: React.FC = () => {
   return (
     <div className="AppSelector">
       {isMobile && pathname.endsWith('/notifications') ? (
-        <>
-          <MobileHeader title="Notifications" />
-        </>
+        <MobileHeader title="Notifications" />
       ) : (
-        <>
-          <Input
-            onChange={({ target }) => {
-              setSearch(target.value)
-            }}
-            placeholder="Search"
-            icon={SearchIcon}
-          />
-          <TargetTitle className="AppSelector__target-title" to="/notifications/new-app">
-            <Text variant="large-700">Inbox</Text>
-          </TargetTitle>
-        </>
+        <Input
+          onChange={({ target }) => {
+            setSearch(target.value)
+          }}
+          placeholder="Search"
+          icon={SearchIcon}
+        />
       )}
+      <TargetTitle className="AppSelector__target-title" to="/notifications/new-app">
+        <Text variant="large-700">Inbox</Text>
+      </TargetTitle>
+      {isMobile && empty && !subscriptionsLoading ? (
+        <div className="AppSelector__empty__message">
+          <Text variant="small-500">You don't have any subscriptions yet</Text>
+        </div>
+      ) : null}
 
       <div className="AppSelector__lists">
         <div className="AppSelector__wrapper">
@@ -132,7 +134,7 @@ const AppSelector: React.FC = () => {
           )}
         </div>
         <div className="AppSelector__wrapper">
-          {!empty ? <Label color="main">Subscribed</Label> : null}
+          {!empty || subscriptionsLoading ? <Label color="main">Subscribed</Label> : null}
           <ul className="AppSelector__list">
             {!loading &&
               filteredApps?.map(app => {
@@ -171,7 +173,7 @@ const AppSelector: React.FC = () => {
                   </AnimatePresence>
                 )
               })}
-            {loading || !subscriptionsFinishedLoading ? SkeletonItems : null}
+            {!subscriptionsLoading ? SkeletonItems : null}
           </ul>
         </div>
       </div>

--- a/src/components/notifications/NotificationsLayout/index.tsx
+++ b/src/components/notifications/NotificationsLayout/index.tsx
@@ -1,8 +1,8 @@
-import React, { Fragment, useContext } from 'react'
+import React, { Fragment, useContext, useEffect } from 'react'
 
 import { AnimatePresence } from 'framer-motion'
 import { motion } from 'framer-motion'
-import { Navigate, Outlet, useLocation } from 'react-router-dom'
+import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 
 import W3iContext from '@/contexts/W3iContext/context'
 
@@ -13,12 +13,15 @@ import './NotificationsLayout.scss'
 const NotificationsLayout: React.FC = () => {
   const { activeSubscriptions } = useContext(W3iContext)
   const { pathname } = useLocation()
+  const nav = useNavigate()
 
-  if (pathname === '/notifications') {
-    if (!activeSubscriptions.length) {
-      return <Navigate to="/notifications/new-app" />
+  useEffect(() => {
+    if (pathname === '/notifications') {
+      if (!activeSubscriptions.length) {
+        nav('/notifications/new-app')
+      }
     }
-  }
+  }, [])
 
   return (
     <Fragment>


### PR DESCRIPTION
# Description

We are forcing users to discover the page when they don't have any subscriptions. This causes a broken experience on the PWA. The notification list check should be on the first load since the list is loaded gradually (not at once). We shouldn't force redirecting to discover every time they open the subscriptions page. 

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/333

# Screenshots

https://github.com/WalletConnect/web3inbox/assets/19428358/74bd18d4-4dce-42c4-ac51-0158016f03ee

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
