### PR TITLE
chore: bump notify 0.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@sentry/react": "^7.64.0",
     "@walletconnect/core": "2.11.0",
     "@walletconnect/identity-keys": "^1.0.1",
-    "@walletconnect/notify-client": "^0.16.2",
+    "@walletconnect/notify-client": "^0.16.3",
     "@walletconnect/notify-message-decrypter": "^0.1.0",
     "@web3modal/wagmi": "3.5.4",
     "classnames": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3395,10 +3395,10 @@
     "@walletconnect/modal-core" "2.6.2"
     "@walletconnect/modal-ui" "2.6.2"
 
-"@walletconnect/notify-client@^0.16.2":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.16.2.tgz#5b74623d2b339e9306f87d240af76dc68fcb95ad"
-  integrity sha512-32Lbddd8B15pxwOasPBJjUx5kzNJYxlsihZvzBFTifIpfK9kZd8frtZ5EUYT9KRceOPj7M5sWgPKse//dqVBsA==
+"@walletconnect/notify-client@^0.16.3":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@walletconnect/notify-client/-/notify-client-0.16.3.tgz#e2cbfb34a92da30a01ee8ebfe86e0376ef66ae80"
+  integrity sha512-T/b/mfuwVIniUK0EwuhW1BJX7iqPSbM7bpS9dDyQowCxJeXBCJVddyo4x62/ecdYVmt+ePt+7b5oXZfmovIMIg==
   dependencies:
     "@noble/ed25519" "^1.7.3"
     "@walletconnect/cacao" "1.0.2"


### PR DESCRIPTION
# Description

- Bump notify 0.16.3  to fix the issue with being unable to unregister due to unsynced state (namely `watchSUbscriptions`, `registrationData` and `identityKeys`)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves #357 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules