### PR TITLE
refactor: dapps subs loading state

### DIFF
--- a/src/components/notifications/AppExplorer/AppCard/AppCard.scss
+++ b/src/components/notifications/AppExplorer/AppCard/AppCard.scss
@@ -202,6 +202,11 @@
       will-change: background-color, box-shadow, color;
       outline: none;
 
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
       @media only screen and (max-width: 700px) {
         display: none;
       }
@@ -232,14 +237,16 @@
         color: #1b2045;
       }
 
-      &:hover,
-      &:focus-visible {
-        box-shadow: inset 0 0 0 2px black;
-        color: black;
-
-        & svg {
-          width: 0.75rem;
+      &:not(:disabled) {
+        &:hover,
+        &:focus-visible {
+          box-shadow: inset 0 0 0 2px black;
           color: black;
+
+          & svg {
+            width: 0.75rem;
+            color: black;
+          }
         }
       }
     }

--- a/src/components/notifications/AppExplorer/AppCard/SubscribeButton.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/SubscribeButton.tsx
@@ -9,6 +9,7 @@ import './AppCard.scss'
 
 interface SubscribeButtonProps {
   className?: string
+  loading?: boolean
   subscribing: boolean
   subscribed: boolean
   onNavigateToApp: () => void
@@ -17,16 +18,21 @@ interface SubscribeButtonProps {
 
 const SubscribeButton: React.FC<SubscribeButtonProps> = ({
   className,
+  loading,
   subscribing,
   subscribed,
   onNavigateToApp,
   onSubscribe
 }) => {
-  if (subscribed) {
+  if (subscribed || loading) {
     return (
-      <button onClick={onNavigateToApp} className={cn('AppCard__body__subscribed', className)}>
-        Subscribed
-        <ChevronRightIcon />
+      <button
+        disabled={loading}
+        onClick={onNavigateToApp}
+        className={cn('AppCard__body__subscribed', className)}
+      >
+        {loading ? null : 'Subscribed'}
+        {loading ? <Spinner /> : <ChevronRightIcon />}
       </button>
     )
   }
@@ -37,7 +43,8 @@ const SubscribeButton: React.FC<SubscribeButtonProps> = ({
       className={cn('AppCard__body__subscribe', className)}
       onClick={onSubscribe}
     >
-      {subscribing ? <Spinner /> : 'Subscribe'}
+      {subscribing ? 'Subscribing' : 'Subscribe'}
+      {subscribing ? <Spinner /> : null}
     </button>
   )
 }

--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -16,6 +16,7 @@ import './AppCard.scss'
 interface AppCardProps {
   name: string
   description: string
+  loadingSubscription: boolean
   logo: string
   url: string
   isVerified?: boolean
@@ -26,6 +27,7 @@ const AppCard: React.FC<AppCardProps> = ({
   description,
   isComingSoon,
   isVerified,
+  loadingSubscription,
   logo,
   name,
   url
@@ -116,6 +118,7 @@ const AppCard: React.FC<AppCardProps> = ({
             subscribing={subscribing}
             onNavigateToApp={handleNavigateApp}
             onSubscribe={handleSubscription}
+            loading={loadingSubscription}
           />
         )}
       </div>
@@ -136,6 +139,7 @@ const AppCard: React.FC<AppCardProps> = ({
             subscribing={subscribing}
             onNavigateToApp={handleNavigateApp}
             onSubscribe={handleSubscription}
+            loading={loadingSubscription}
           />
         )}
       </div>

--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -46,7 +46,11 @@ const AppCard: React.FC<AppCardProps> = ({
   }, [userPubkey])
 
   const subscribed =
-    userPubkey && activeSubscriptions.some(element => element.metadata.name === name)
+    userPubkey &&
+    activeSubscriptions.some(element => {
+      const projectURL = new URL(url)
+      return projectURL.hostname === element.metadata.appDomain
+    })
   const logoURL = logo || '/fallback.svg'
 
   const handleSubscription = useCallback(

--- a/src/components/notifications/AppExplorer/index.tsx
+++ b/src/components/notifications/AppExplorer/index.tsx
@@ -7,6 +7,7 @@ import IntroApps from '@/components/general/Icon/IntroApps'
 import IntroContent from '@/components/general/IntroContent'
 import MobileHeader from '@/components/layout/MobileHeader'
 import { COMING_SOON_PROJECTS } from '@/constants/projects'
+import W3iContext from '@/contexts/W3iContext/context'
 import useNotifyProjects from '@/utils/hooks/useNotifyProjects'
 
 import AppCard from './AppCard'
@@ -15,9 +16,23 @@ import AppCardSkeleton from './AppCardSkeleton'
 import './AppExplorer.scss'
 
 const AppExplorer = () => {
+  const { activeSubscriptions, watchSubscriptionsComplete: subscriptionsFinishedLoading } =
+    useContext(W3iContext)
   const { projects, loading } = useNotifyProjects()
 
   const allProjects = projects.concat(COMING_SOON_PROJECTS)
+
+  const checkLoadingSubscriptionStatus = (projectDomain: string) => {
+    if (subscriptionsFinishedLoading) {
+      return activeSubscriptions.find(
+        subscription => subscription.metadata.appDomain === projectDomain
+      )
+        ? true
+        : false
+    }
+
+    return true
+  }
 
   return (
     <AnimatePresence>
@@ -65,6 +80,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
+                    loadingSubscription={checkLoadingSubscriptionStatus(app.url)}
                   />
                 ))}
             </div>
@@ -80,6 +96,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
+                    loadingSubscription={checkLoadingSubscriptionStatus(app.url)}
                   />
                 ))}
             </div>

--- a/src/components/notifications/AppExplorer/index.tsx
+++ b/src/components/notifications/AppExplorer/index.tsx
@@ -23,12 +23,12 @@ const AppExplorer = () => {
   const allProjects = projects.concat(COMING_SOON_PROJECTS)
 
   const checkSubscriptionStatusLoading = (url: string) => {
-    const existInSubscriptions = activeSubscriptions.find(subscription => {
-      const projectURL = new URL(url)
-      return projectURL.hostname === subscription.metadata.appDomain
-    })
-
     if (!subscriptionsFinishedLoading) {
+      const existInSubscriptions = activeSubscriptions.find(subscription => {
+        const projectURL = new URL(url)
+        return projectURL.hostname === subscription.metadata.appDomain
+      })
+
       return existInSubscriptions ? false : true
     }
 

--- a/src/components/notifications/AppExplorer/index.tsx
+++ b/src/components/notifications/AppExplorer/index.tsx
@@ -22,10 +22,11 @@ const AppExplorer = () => {
 
   const allProjects = projects.concat(COMING_SOON_PROJECTS)
 
-  const checkSubscriptionStatusLoading = (projectName: string) => {
-    const existInSubscriptions = activeSubscriptions.find(
-      subscription => subscription.metadata.name === projectName
-    )
+  const checkSubscriptionStatusLoading = (url: string) => {
+    const existInSubscriptions = activeSubscriptions.find(subscription => {
+      const projectURL = new URL(url)
+      return projectURL.hostname === subscription.metadata.appDomain
+    })
 
     if (!subscriptionsFinishedLoading) {
       return existInSubscriptions ? false : true
@@ -80,7 +81,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
-                    loadingSubscription={checkSubscriptionStatusLoading(app.name)}
+                    loadingSubscription={checkSubscriptionStatusLoading(app.url)}
                   />
                 ))}
             </div>
@@ -96,7 +97,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
-                    loadingSubscription={checkSubscriptionStatusLoading(app.name)}
+                    loadingSubscription={checkSubscriptionStatusLoading(app.url)}
                   />
                 ))}
             </div>

--- a/src/components/notifications/AppExplorer/index.tsx
+++ b/src/components/notifications/AppExplorer/index.tsx
@@ -22,16 +22,16 @@ const AppExplorer = () => {
 
   const allProjects = projects.concat(COMING_SOON_PROJECTS)
 
-  const checkLoadingSubscriptionStatus = (projectDomain: string) => {
-    if (subscriptionsFinishedLoading) {
-      return activeSubscriptions.find(
-        subscription => subscription.metadata.appDomain === projectDomain
-      )
-        ? true
-        : false
+  const checkSubscriptionStatusLoading = (projectName: string) => {
+    const existInSubscriptions = activeSubscriptions.find(
+      subscription => subscription.metadata.name === projectName
+    )
+
+    if (!subscriptionsFinishedLoading) {
+      return existInSubscriptions ? false : true
     }
 
-    return true
+    return false
   }
 
   return (
@@ -80,7 +80,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
-                    loadingSubscription={checkLoadingSubscriptionStatus(app.url)}
+                    loadingSubscription={checkSubscriptionStatusLoading(app.name)}
                   />
                 ))}
             </div>
@@ -96,7 +96,7 @@ const AppExplorer = () => {
                     url={app.url}
                     isVerified={app.isVerified}
                     isComingSoon={app.isComingSoon}
-                    loadingSubscription={checkLoadingSubscriptionStatus(app.url)}
+                    loadingSubscription={checkSubscriptionStatusLoading(app.name)}
                   />
                 ))}
             </div>


### PR DESCRIPTION
# Description

Adding control logic to app cards in the discovery page to show the loading state before we have the subscription data. This will fix the logic that we're showing the "Subscribe" button even though we subscribed but since we haven't loaded all subscriptions yet, it's misleading us and results bad UX.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/329

# Examples/Screenshots (Optional)


https://github.com/WalletConnect/web3inbox/assets/19428358/e25b504b-2f49-49de-a30d-75b1bd19f10e


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)


