### PR TITLE
fix: ensure every error toast logs the underlying error to console

### DIFF
--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -49,6 +49,7 @@ const AppCard: React.FC<AppCardProps> = ({
     userPubkey &&
     activeSubscriptions.some(element => {
       const projectURL = new URL(url)
+
       return projectURL.hostname === element.metadata.appDomain
     })
   const logoURL = logo || '/fallback.svg'
@@ -74,6 +75,7 @@ const AppCard: React.FC<AppCardProps> = ({
           appDomain: new URL(url).host
         })
       } catch (error) {
+        console.error(error)
         setSubscribing(false)
         showErrorMessageToast(`Failed to subscribe to ${name}`)
       }

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -46,8 +46,10 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     })
   }, [notifyClient, userPubkey, proxyReady])
 
-  // it takes time for handshake (watch subscriptions) to complete
-  // load in progress state using interval until it is
+  /*
+   * It takes time for handshake (watch subscriptions) to complete
+   * load in progress state using interval until it is
+   */
   useEffect(() => {
     if (notifyClient?.hasFinishedInitialLoad()) {
       setWatchSubscriptionsComplete(true)
@@ -74,6 +76,7 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
           setRegistered(identityKey)
           refreshNotifyState()
         } catch (error) {
+          console.error(error)
           setRegisterMessage(null)
         }
       }

--- a/src/pages/widget/Subscribe/index.tsx
+++ b/src/pages/widget/Subscribe/index.tsx
@@ -43,7 +43,8 @@ const WidgetSubscribe: React.FC = () => {
         appDomain: new URL(dappOrigin).host
       })
     } catch (error) {
-      showErrorMessageToast('Failed to subscribe')
+      console.error(error)
+      showErrorMessageToast(`Failed to subscribe to ${dappOrigin}`)
     } finally {
       setIsSubscribing(false)
     }

--- a/src/utils/hooks/useNotifyProjects.ts
+++ b/src/utils/hooks/useNotifyProjects.ts
@@ -41,7 +41,7 @@ const useNotifyProjects = () => {
             url: item.dapp_url,
             icon: item.image_url?.md ?? '/fallback.svg',
             colors: item.metadata?.colors,
-            isVerified: item.is_verified || item.isVerified ? true : false,
+            isVerified: Boolean(item.is_verified || item.isVerified),
             isFeatured: item.is_featured,
             isComingSoon: item.is_coming_soon
           }))
@@ -49,11 +49,12 @@ const useNotifyProjects = () => {
 
         notifyApps.concat(COMING_SOON_PROJECTS)
 
-        setLoading(false)
         setProjects(notifyApps)
       } catch (error) {
-        setLoading(false)
+        console.error(error)
         setProjects([])
+      } finally {
+        setLoading(false)
       }
     }
 

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -11,15 +11,15 @@ export async function fetchFeaturedProjects<T>() {
 
   try {
     const discoverProjectsData = await fetch(explorerUrlFeatured)
-      .then(res => res.json())
-      .catch(err => console.log({ featuredProjects: err }))
+      .then(async res => res.json())
+      .catch(err => console.error({ featuredProjects: err }))
     const discoverProjects = Object.values(discoverProjectsData.projects)
 
     return {
       data: discoverProjects as T
     }
   } catch (error) {
-    throw new Error('Error fetching featured projects')
+    throw new Error(`Error fetching featured projects: ${error}`)
   }
 }
 
@@ -35,13 +35,13 @@ export async function fetchDomainProjects<T>(domain: string) {
   explorerUrlAppDomain.searchParams.set('appDomain', domain)
 
   try {
-    const domainProjectsData = await fetch(explorerUrlAppDomain).then(res => res.json())
+    const domainProjectsData = await fetch(explorerUrlAppDomain).then(async res => res.json())
     domainProject = domainProjectsData.data as T
 
     return {
       data: domainProject
     }
   } catch (error) {
-    throw new Error('Error fetching domain project')
+    throw new Error(`Error fetching projects for domain: ${error}`)
   }
 }


### PR DESCRIPTION
# Description

- Context: https://walletconnect.slack.com/archives/C044SKFKELR/p1704993119733469?thread_ts=1704976288.139559&cid=C044SKFKELR
- We were catching some errors and showing user friendly toasts without processing the underlying error in an observable way.
- Ensure every `catch + showErrorMessageToast` is paired to a `console.error` call
- Any other changes are ESLint/Prettier auto-fixes

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

