### PR TITLE
chore: add event handlers on sw to handle notifs

### DIFF
--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -52,3 +52,11 @@ onBackgroundMessage(messaging, async ev => {
     body: m.body
   })
 })
+
+self.addEventListener('notificationclick', function (event) {
+  console.log('>>> SW: notificationclick', event)
+  var urlToRedirect = event.notification.data.url || 'https://app.web3inbox.com'
+
+  event.notification.close()
+  event.waitUntil(self.clients.openWindow(urlToRedirect))
+})

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -49,7 +49,8 @@ onBackgroundMessage(messaging, async ev => {
 
   return self.registration.showNotification(m.title, {
     icon: m.icon,
-    body: m.body
+    body: m.body,
+    data: { url: m.url }
   })
 })
 

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -55,16 +55,17 @@ onBackgroundMessage(messaging, async ev => {
 })
 
 self.addEventListener('notificationclick', e => {
-  console.log('>>> notificationonclick: event:', e)
-  const url =
-    e.notification?.data?.url || 'https://app-w3i-service-worker.vercel.app//notifications/new-app'
+  const url = e.notification?.data?.url
 
   e.notification.close()
+
+  if (!url) {
+    return
+  }
+
   e.waitUntil(
-    self.clients.matchAll({ type: 'window' }).then(clientsArr => {
-      console.log('>>> notificationonclick: clientsArr:', clientsArr)
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientsArr => {
       const hadWindowToFocus = clientsArr.some(windowClient => {
-        console.log('>>> notificationonclick: client:', windowClient)
         return windowClient.url === url ? (windowClient.focus(), true) : false
       })
       if (!hadWindowToFocus) {

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -54,9 +54,9 @@ onBackgroundMessage(messaging, async ev => {
 })
 
 self.addEventListener('notificationclick', e => {
-  const url =
-    e.notification.data.url || 'https://app-w3i-service-worker.vercel.app//notifications/new-app'
   console.log('>>> notificationonclick: event:', e)
+  const url =
+    e.notification?.data?.url || 'https://app-w3i-service-worker.vercel.app//notifications/new-app'
 
   e.notification.close()
   e.waitUntil(

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -54,16 +54,23 @@ onBackgroundMessage(messaging, async ev => {
 })
 
 self.addEventListener('notificationclick', e => {
+  const url =
+    e.notification.data.url || 'https://app-w3i-service-worker.vercel.app//notifications/new-app'
+  console.log('>>> notificationonclick: event:', e)
+
   e.notification.close()
   e.waitUntil(
     self.clients.matchAll({ type: 'window' }).then(clientsArr => {
-      const hadWindowToFocus = clientsArr.some(windowClient =>
-        windowClient.url === e.notification.data.url ? (windowClient.focus(), true) : false
-      )
-      if (!hadWindowToFocus)
+      console.log('>>> notificationonclick: clientsArr:', clientsArr)
+      const hadWindowToFocus = clientsArr.some(windowClient => {
+        console.log('>>> notificationonclick: client:', windowClient)
+        return windowClient.url === url ? (windowClient.focus(), true) : false
+      })
+      if (!hadWindowToFocus) {
         self.clients
-          .openWindow('https://app.web3inbox.com')
+          .openWindow(url)
           .then(windowClient => (windowClient ? windowClient.focus() : null))
+      }
     })
   )
 })

--- a/src/firebase-messaging-sw.ts
+++ b/src/firebase-messaging-sw.ts
@@ -53,10 +53,17 @@ onBackgroundMessage(messaging, async ev => {
   })
 })
 
-self.addEventListener('notificationclick', function (event) {
-  console.log('>>> SW: notificationclick', event)
-  var urlToRedirect = event.notification.data.url || 'https://app.web3inbox.com'
-
-  event.notification.close()
-  event.waitUntil(self.clients.openWindow(urlToRedirect))
+self.addEventListener('notificationclick', e => {
+  e.notification.close()
+  e.waitUntil(
+    self.clients.matchAll({ type: 'window' }).then(clientsArr => {
+      const hadWindowToFocus = clientsArr.some(windowClient =>
+        windowClient.url === e.notification.data.url ? (windowClient.focus(), true) : false
+      )
+      if (!hadWindowToFocus)
+        self.clients
+          .openWindow('https://app.web3inbox.com')
+          .then(windowClient => (windowClient ? windowClient.focus() : null))
+    })
+  )
 })

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -55,7 +55,7 @@ self.addEventListener('push', event => {
   // Store data for the app to access later
   // Show a notification
   self.registration.showNotification(data.title, {
-    body: data.body
+    body: data.body,
     icon: data.icon,
     vibrate: [200, 100, 200],
     actions: [

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -41,6 +41,7 @@ self.addEventListener('message', event => {
 // In your service worker
 self.addEventListener('push', event => {
   console.log('>>> SW: push event', event)
+  // --------
   const data = event?.data?.json()
   // Store data for the app to access later
   // Show a notification
@@ -52,8 +53,8 @@ self.addEventListener('push', event => {
 
 self.addEventListener('notificationclick', event => {
   console.log('>>> SW: notificationclick event', event)
+  // --------
   event.notification.close()
-
   event.waitUntil(
     self.clients.openWindow('/') // Opens your app
   )

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -56,6 +56,18 @@ self.addEventListener('push', event => {
   // Show a notification
   self.registration.showNotification(data.title, {
     body: data.body
+    icon: data.icon,
+    vibrate: [200, 100, 200],
+    actions: [
+      {
+        action: 'view',
+        title: 'View'
+      },
+      {
+        action: 'dismiss',
+        title: 'Dismiss'
+      }
+    ]
     // other options
   })
 })

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -26,15 +26,6 @@ self.ononline = () => {
   clearCache()
 }
 
-self.addEventListener('notificationclick', event => {
-  console.log('>>> SW: notificationclick event', event)
-  event.notification.close()
-})
-
-self.addEventListener('notificationclose', event => {
-  console.log('>>> SW: notificationclose event', event)
-})
-
 self.addEventListener('message', event => {
   console.log('>>> SW: message', event?.data)
   if (!event.data) return

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -12,18 +12,22 @@ const clearCache = () => {
 
 // Clear any cache
 self.oninstall = () => {
+  console.log('>>> SW: oninstall')
   clearCache()
 }
 
 self.onactivate = () => {
+  console.log('>>> SW: oninactive')
   clearCache()
 }
 
 self.ononline = () => {
+  console.log('>>> SW: ononline')
   clearCache()
 }
 
 self.addEventListener('message', event => {
+  console.log('>>> SW: message', event?.data)
   if (!event.data) return
 
   switch (event.data.type) {
@@ -32,6 +36,27 @@ self.addEventListener('message', event => {
       self.skipWaiting()
       break
   }
+})
+
+// In your service worker
+self.addEventListener('push', event => {
+  console.log('>>> SW: push event', event)
+  const data = event?.data?.json()
+  // Store data for the app to access later
+  // Show a notification
+  self.registration.showNotification(data.title, {
+    body: data.body
+    // other options
+  })
+})
+
+self.addEventListener('notificationclick', event => {
+  console.log('>>> SW: notificationclick event', event)
+  event.notification.close()
+
+  event.waitUntil(
+    self.clients.openWindow('/') // Opens your app
+  )
 })
 
 self.addEventListener('install', () => {

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -26,6 +26,15 @@ self.ononline = () => {
   clearCache()
 }
 
+self.addEventListener('notificationclick', event => {
+  console.log('>>> SW: notificationclick event', event)
+  event.notification.close()
+})
+
+self.addEventListener('notificationclose', event => {
+  console.log('>>> SW: notificationclose event', event)
+})
+
 self.addEventListener('message', event => {
   console.log('>>> SW: message', event?.data)
   if (!event.data) return
@@ -49,15 +58,6 @@ self.addEventListener('push', event => {
     body: data.body
     // other options
   })
-})
-
-self.addEventListener('notificationclick', event => {
-  console.log('>>> SW: notificationclick event', event)
-  // --------
-  event.notification.close()
-  event.waitUntil(
-    self.clients.openWindow('/') // Opens your app
-  )
 })
 
 self.addEventListener('install', () => {

--- a/src/main-sw.ts
+++ b/src/main-sw.ts
@@ -12,22 +12,18 @@ const clearCache = () => {
 
 // Clear any cache
 self.oninstall = () => {
-  console.log('>>> SW: oninstall')
   clearCache()
 }
 
 self.onactivate = () => {
-  console.log('>>> SW: oninactive')
   clearCache()
 }
 
 self.ononline = () => {
-  console.log('>>> SW: ononline')
   clearCache()
 }
 
 self.addEventListener('message', event => {
-  console.log('>>> SW: message', event?.data)
   if (!event.data) return
 
   switch (event.data.type) {
@@ -36,31 +32,6 @@ self.addEventListener('message', event => {
       self.skipWaiting()
       break
   }
-})
-
-// In your service worker
-self.addEventListener('push', event => {
-  console.log('>>> SW: push event', event)
-  // --------
-  const data = event?.data?.json()
-  // Store data for the app to access later
-  // Show a notification
-  self.registration.showNotification(data.title, {
-    body: data.body,
-    icon: data.icon,
-    vibrate: [200, 100, 200],
-    actions: [
-      {
-        action: 'view',
-        title: 'View'
-      },
-      {
-        action: 'dismiss',
-        title: 'Dismiss'
-      }
-    ]
-    // other options
-  })
 })
 
 self.addEventListener('install', () => {


### PR DESCRIPTION
# Description

We were missing a notification handler to take certain actions on click to notification on the desktop. Refactored the Firebase service worker to pass `url` to the `data` prop of the event handler's body. 

Unlike the mobile devices, the notification handler doesn't have `url` handler as you can see the documentation below. We should pass the url to `data` object and handle the data fields inside the `notificationonclick` event handler and take action. Here, we're doing a basic thing which is opening the URL in the browser.

- MDN Docs - [ServiceWorkerRegistiration](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerRegistration/showNotification)


# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/353

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules