### PR TITLE
refactor: move the subscription complete handler on useEffect

### DIFF
--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -62,12 +62,6 @@ const AppCard: React.FC<AppCardProps> = ({
         return
       }
 
-      if (subscribing && subscribed) {
-        showSuccessMessageToast(`Subscribed to ${name}`)
-
-        return
-      }
-
       setSubscribing(true)
       try {
         await notifyClientProxy?.subscribe({
@@ -82,6 +76,12 @@ const AppCard: React.FC<AppCardProps> = ({
     },
     [userPubkey, name, description, logo, url, setSubscribing, subscribed, notifyClientProxy]
   )
+
+  useEffect(() => {
+    if (subscribing && subscribed) {
+      showSuccessMessageToast(`Subscribed to ${name}`)
+    }
+  }, [subscribing, subscribed])
 
   const handleNavigateApp = () => {
     if (subscribed) {

--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -96,6 +96,7 @@ const AppCard: React.FC<AppCardProps> = ({
   useEffect(() => {
     if (subscribing && subscribed) {
       showSuccessMessageToast(`Subscribed to ${name}`)
+      setSubscribing(false)
     }
   }, [subscribing, subscribed])
 

--- a/src/components/notifications/AppExplorer/AppCard/index.tsx
+++ b/src/components/notifications/AppExplorer/AppCard/index.tsx
@@ -77,12 +77,6 @@ const AppCard: React.FC<AppCardProps> = ({
     [userPubkey, name, description, logo, url, setSubscribing, subscribed, notifyClientProxy]
   )
 
-  useEffect(() => {
-    if (subscribing && subscribed) {
-      showSuccessMessageToast(`Subscribed to ${name}`)
-    }
-  }, [subscribing, subscribed])
-
   const handleNavigateApp = () => {
     if (subscribed) {
       try {
@@ -98,6 +92,12 @@ const AppCard: React.FC<AppCardProps> = ({
       }
     }
   }
+
+  useEffect(() => {
+    if (subscribing && subscribed) {
+      showSuccessMessageToast(`Subscribed to ${name}`)
+    }
+  }, [subscribing, subscribed])
 
   return (
     <div


### PR DESCRIPTION
# Description

Since we're calling the `handleSubmit` at once and the `subscribed` and `subscribing` values changing over time. We should watch these values in `useEffect` to handle subscribed state and take action (like show a toast message).

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox-planning/issues/51

# Examples/Screenshots (Optional)


https://github.com/WalletConnect/web3inbox/assets/19428358/71063d75-68bb-4c99-adf7-909c5b8e71ab



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
