### PR TITLE
Fix/force watch subscriptions

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -6,7 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 // require('dotenv').config();
 
-const baseURL = 'http://localhost:5173';
+const baseURL = 'http://localhost:5173'
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -31,25 +31,25 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
 
-    screenshot: 'only-on-failure',
+    screenshot: 'only-on-failure'
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: { ...devices['Desktop Chrome'] }
     },
 
     {
       name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      use: { ...devices['Desktop Firefox'] }
     },
 
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
+      use: { ...devices['Desktop Safari'] }
+    }
 
     /* Test against mobile viewports. */
     // {
@@ -76,6 +76,6 @@ export default defineConfig({
   webServer: {
     command: 'yarn dev',
     url: baseURL,
-    reuseExistingServer: !process.env.CI,
-  },
-});
+    reuseExistingServer: !process.env.CI
+  }
+})

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -66,6 +66,14 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     return () => clearInterval(intervalId)
   }, [refreshNotifyState, watchSubscriptionsComplete])
 
+  const handleUnregisterOthers = useCallback(
+    async (key: string) => {
+      if (!(notifyClient && key && uiEnabled.notify)) {
+	return
+      }
+      await notifyClient.unregisterOtherAccounts(key);
+    }, [notifyClient])
+
   const handleRegistration = useCallback(
     async (key: string) => {
       if (notifyClient && key && uiEnabled.notify) {
@@ -90,7 +98,9 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
 
   useEffect(() => {
     if (userPubkey) {
-      handleRegistration(userPubkey)
+      handleUnregisterOthers(userPubkey).then(() => {
+        handleRegistration(userPubkey)
+      })
     } else {
       setRegisterMessage(null)
     }

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -51,15 +51,15 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
    * load in progress state using interval until it is
    */
   useEffect(() => {
-    if(watchSubscriptionsComplete) {
-      return noop;
+    if (watchSubscriptionsComplete) {
+      return noop
     }
     // Account for sync init
     const intervalId = setInterval(() => {
-    if (notifyClient?.hasFinishedInitialLoad()) {
-      setWatchSubscriptionsComplete(true)
-      return noop;
-    }
+      if (notifyClient?.hasFinishedInitialLoad()) {
+        setWatchSubscriptionsComplete(true)
+        return noop
+      }
       refreshNotifyState()
     }, 100)
 
@@ -69,10 +69,12 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
   const handleUnregisterOthers = useCallback(
     async (key: string) => {
       if (!(notifyClient && key && uiEnabled.notify)) {
-	return
+        return
       }
-      await notifyClient.unregisterOtherAccounts(key);
-    }, [notifyClient])
+      await notifyClient.unregisterOtherAccounts(key)
+    },
+    [notifyClient]
+  )
 
   const handleRegistration = useCallback(
     async (key: string) => {

--- a/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
@@ -78,6 +78,11 @@ export default class ExternalNotifyProvider implements W3iNotifyProvider {
     return true
   }
 
+  public async unregister() {
+    // TODO: remove this whole provider
+    return 
+  }
+
   public async register() {
     // TODO: remove this whole provider
     return 'not implemented'

--- a/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
@@ -78,6 +78,11 @@ export default class ExternalNotifyProvider implements W3iNotifyProvider {
     return true
   }
 
+  public async unregisterOtherAccounts() {
+    // TODO: remove this whole provider
+    return 
+  }
+
   public async unregister() {
     // TODO: remove this whole provider
     return 

--- a/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/externalNotifyProvider.ts
@@ -80,12 +80,12 @@ export default class ExternalNotifyProvider implements W3iNotifyProvider {
 
   public async unregisterOtherAccounts() {
     // TODO: remove this whole provider
-    return 
+    return
   }
 
   public async unregister() {
     // TODO: remove this whole provider
-    return 
+    return
   }
 
   public async register() {

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -56,8 +56,6 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     // Ensure we have a registration with echo (if we need it)
     this.ensureEchoRegistration()
     updateSymkeyState()
-
-
   }
 
   // ------------------------ Provider-specific methods ------------------------
@@ -110,7 +108,7 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     return this.notifyClient?.hasFinishedInitialLoad() || false
   }
 
-  public async unregister(params: {account: string}) {
+  public async unregister(params: { account: string }) {
     if (!this.notifyClient) {
       throw new Error(this.formatClientRelatedError('unregister'))
     }
@@ -260,12 +258,13 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       throw new Error(this.formatClientRelatedError('unregisterOtherAccounts'))
     }
 
-    const otherAccounts = this.notifyClient.identityKeys.identityKeys.getAll()
-      .map(({accountId}) => accountId)
-      .filter(account => account !== currentAccount);
+    const otherAccounts = this.notifyClient.identityKeys.identityKeys
+      .getAll()
+      .map(({ accountId }) => accountId)
+      .filter(account => account !== currentAccount)
 
-    for(const account of otherAccounts) {
-      await this.notifyClient.unregister({account})
+    for (const account of otherAccounts) {
+      await this.notifyClient.unregister({ account })
     }
   }
 }

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -56,6 +56,8 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     // Ensure we have a registration with echo (if we need it)
     this.ensureEchoRegistration()
     updateSymkeyState()
+
+
   }
 
   // ------------------------ Provider-specific methods ------------------------
@@ -108,9 +110,16 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
     return this.notifyClient?.hasFinishedInitialLoad() || false
   }
 
+  public async unregister(params: {account: string}) {
+    if (!this.notifyClient) {
+      throw new Error(this.formatClientRelatedError('unregister'))
+    }
+    return this.notifyClient.unregister(params)
+  }
+
   public async register(params: { account: string; domain: string; isLimited?: boolean }) {
     if (!this.notifyClient) {
-      throw new Error(this.formatClientRelatedError('approve'))
+      throw new Error(this.formatClientRelatedError('register'))
     }
 
     const props = {

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -253,4 +253,19 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
 
     return Boolean(existingRegistration)
   }
+
+  // ---------- Custom functions ------------- //
+  public async unregisterOtherAccounts(currentAccount: string) {
+    if (!this.notifyClient) {
+      throw new Error(this.formatClientRelatedError('unregisterOtherAccounts'))
+    }
+
+    const otherAccounts = this.notifyClient.identityKeys.identityKeys.getAll()
+      .map(({accountId}) => accountId)
+      .filter(account => account !== currentAccount);
+
+    for(const account of otherAccounts) {
+      await this.notifyClient.unregister({account})
+    }
+  }
 }

--- a/src/w3iProxy/notifyProviders/types.ts
+++ b/src/w3iProxy/notifyProviders/types.ts
@@ -36,9 +36,7 @@ type NonMethodNotifyClientKeys =
   | 'isRegistered'
   | 'register'
   | 'requests'
-  // unregister functionality is not present in web3inbox at the moment.
-  | 'unregister'
-  | 'subscriptions'
+  | 'subscription'
   | 'syncClient'
   | 'SyncStoreController'
   | 'version'

--- a/src/w3iProxy/notifyProviders/types.ts
+++ b/src/w3iProxy/notifyProviders/types.ts
@@ -36,7 +36,7 @@ type NonMethodNotifyClientKeys =
   | 'isRegistered'
   | 'register'
   | 'requests'
-  | 'subscription'
+  | 'subscriptions'
   | 'syncClient'
   | 'SyncStoreController'
   | 'version'

--- a/src/w3iProxy/notifyProviders/types.ts
+++ b/src/w3iProxy/notifyProviders/types.ts
@@ -53,6 +53,7 @@ interface ModifiedNotifyClientFunctions {
   registerWithEcho: () => Promise<void>
   getRegisteredWithEcho: () => Promise<boolean>
   register: (params: { account: string; domain: string; isLimited?: boolean }) => Promise<string>
+  unregisterOtherAccounts: (currentAccount: string) => Promise<void>
 }
 
 export type NotifyClientFunctions = Omit<NotifyClient, NonMethodNotifyClientKeys>

--- a/src/w3iProxy/w3iNotifyFacade.ts
+++ b/src/w3iProxy/w3iNotifyFacade.ts
@@ -91,12 +91,18 @@ class W3iNotifyFacade implements W3iNotify {
     return this.provider.getNotificationHistory(params)
   }
 
+  // ------- Custom functions ------------------- //
+
   public async registerWithEcho() {
     return this.provider.registerWithEcho()
   }
 
   public async getRegisteredWithEcho() {
     return this.provider.getRegisteredWithEcho()
+  }
+
+  public async unregisterOtherAccounts(currentAccount: string) {
+    this.provider.unregisterOtherAccounts(currentAccount);
   }
 }
 

--- a/src/w3iProxy/w3iNotifyFacade.ts
+++ b/src/w3iProxy/w3iNotifyFacade.ts
@@ -53,6 +53,10 @@ class W3iNotifyFacade implements W3iNotify {
 
   // ------------------ Notify Client Forwarding ------------------
 
+  public async unregister(params: { account: string; }) {
+    return this.provider.unregister(params)
+  }
+
   public async register(params: { account: string; domain: string; isLimited?: boolean }) {
     return this.provider.register(params)
   }

--- a/src/w3iProxy/w3iNotifyFacade.ts
+++ b/src/w3iProxy/w3iNotifyFacade.ts
@@ -53,7 +53,7 @@ class W3iNotifyFacade implements W3iNotify {
 
   // ------------------ Notify Client Forwarding ------------------
 
-  public async unregister(params: { account: string; }) {
+  public async unregister(params: { account: string }) {
     return this.provider.unregister(params)
   }
 
@@ -102,7 +102,7 @@ class W3iNotifyFacade implements W3iNotify {
   }
 
   public async unregisterOtherAccounts(currentAccount: string) {
-    this.provider.unregisterOtherAccounts(currentAccount);
+    this.provider.unregisterOtherAccounts(currentAccount)
   }
 }
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,11 +1,11 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test'
 
 test('has title', async ({ page }) => {
-  await page.goto("/");
-  await expect(page).toHaveTitle(/Web3Inbox/);
-});
+  await page.goto('/')
+  await expect(page).toHaveTitle(/Web3Inbox/)
+})
 
 test('welcome message', async ({ page }) => {
-  await page.goto("/");
-  await expect(page.getByText("Welcome to Web3Inbox")).toBeVisible();
-});
+  await page.goto('/')
+  await expect(page.getByText('Welcome to Web3Inbox')).toBeVisible()
+})


### PR DESCRIPTION
# Description
- Add new custom method to SDK, unregister other users when registering with a different wallet
- This is because the intended UX is switching accounts is akin to logging in
- Furthermore, solves a bug where a switching accounts doesn't re initiate account subscription watching because `register` was never called
# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

