### PR TITLE
refactor: update toast messages

### DIFF
--- a/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
@@ -10,7 +10,7 @@ import Text from '@/components/general/Text'
 import W3iContext from '@/contexts/W3iContext/context'
 import { useModals } from '@/utils/hooks'
 import { unsubscribeModalService } from '@/utils/store'
-import { showErrorMessageToast, showSuccessMessageToast } from '@/utils/toasts'
+import { showDefaultToast, showErrorMessageToast } from '@/utils/toasts'
 
 import './UnsubscribeModal.scss'
 
@@ -32,9 +32,7 @@ export const UnsubscribeModal: React.FC = () => {
         notifyClientProxy.observeOne('notify_delete', {
           next: () => {
             unsubscribeModalService.closeModal()
-            showSuccessMessageToast(
-              `Successfully unsubscribed from ${app ? app.metadata.name : `dapp`}`
-            )
+            showDefaultToast(`Unsubscribed from ${app ? app.metadata.name : `dapp`}`)
             setLoading(false)
             navigate('/notifications/new-app')
           }

--- a/src/utils/toasts.ts
+++ b/src/utils/toasts.ts
@@ -1,5 +1,9 @@
 import toast from 'react-hot-toast'
 
+export const showDefaultToast = (message: string) => {
+  toast(message)
+}
+
 export const showSuccessMessageToast = (message: string) => {
   toast.success(message)
 }


### PR DESCRIPTION
# Description

Refactor toast messages and toast styles for subbscribe and unsubscribe styles.

- Unsubscribe toast: (default toast): "Subscribed from [DAPP]"
- Subscribe toast: (success toast): "Subscribed to [DAPP]"

# Type of change

- [x] Refactor (non-breaking change which fixes an issue)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/396

# Examples/Screenshots (Optional)

<img width="270" alt="Screenshot 2024-01-14 at 09 01 26" src="https://github.com/WalletConnect/web3inbox/assets/19428358/fba1ea3f-af2f-451e-9fd1-e38b60f87820">

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
