### PR TITLE
refactor: website link escape hatch

### DIFF
--- a/src/components/utils/PwaModal/PwaModal.scss
+++ b/src/components/utils/PwaModal/PwaModal.scss
@@ -1,5 +1,6 @@
 .PwaModal {
-  padding: 3em;
+  padding: 3rem;
+  padding-bottom: 2rem;
   display: flex;
   flex-direction: column;
   text-align: center;
@@ -45,6 +46,22 @@
       width: 1em;
       height: 1em;
       display: inline-block;
+    }
+  }
+
+  &__footer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-top: 0.5rem;
+
+    &__title {
+      color: var(--fg-color-2);
+    }
+
+    &__link {
+      color: var(--accent-color-1);
+      text-decoration: none;
     }
   }
 }

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { detect } from 'detect-browser'
+import { Link } from 'react-router-dom'
 
 import BackgroundImage from '@/assets/IntroBackground.png'
 import AndroidShareIcon from '@/components/general/Icon/AndroidShare'
@@ -40,7 +41,7 @@ export const getPlatformInstallText = () => {
       return 'Install App'
     case 'safari':
     case 'ios':
-      return 'Add to homescreen'
+      return 'Add to Home Screen'
     default:
       return 'Install'
   }
@@ -69,6 +70,19 @@ export const PwaModal: React.FC = () => {
           <Text variant="small-500">Just tap </Text>
           <span className="PwaModal__share-icon">{getMobilePlatformIcon()}</span>
           <Text variant="small-500"> and “{getPlatformInstallText()}”</Text>
+        </div>
+        <div className="PwaModal__footer">
+          <Text className="PwaModal__footer__title" variant="small-400">
+            Learn more at&nbsp;
+          </Text>
+          <Link
+            className="PwaModal__footer__link"
+            to="https://web3inbox.com"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <Text variant="small-400">web3inbox.com</Text>
+          </Link>
         </div>
       </div>
     </Modal>

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -6,9 +6,9 @@ import { Link } from 'react-router-dom'
 import BackgroundImage from '@/assets/IntroBackground.png'
 import AndroidShareIcon from '@/components/general/Icon/AndroidShare'
 import IShareIcon from '@/components/general/Icon/IShare'
-import WalletConnectIcon from '@/components/general/Icon/WalletConnectIcon'
 import { Modal } from '@/components/general/Modal/Modal'
 import Text from '@/components/general/Text'
+import { web3InboxURLs } from '@/constants/navigation'
 import { pwaModalService } from '@/utils/store'
 
 import './PwaModal.scss'
@@ -77,7 +77,7 @@ export const PwaModal: React.FC = () => {
           </Text>
           <Link
             className="PwaModal__footer__link"
-            to="https://web3inbox.com"
+            to={web3InboxURLs.website}
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/src/pages/Login/Login.scss
+++ b/src/pages/Login/Login.scss
@@ -28,8 +28,10 @@
     overflow-x: hidden;
     padding: 1rem 0.085em;
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+    gap: 4rem;
 
     @supports (height: 100dvh) {
       height: 100dvh;
@@ -37,6 +39,21 @@
 
     &__connect-button {
       min-width: fit-content;
+    }
+
+    &__footer {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+      &__title {
+        color: var(--fg-color-2);
+      }
+
+      &__link {
+        color: var(--accent-color-1);
+        text-decoration: none;
+      }
     }
   }
 }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,11 +1,12 @@
 import React, { useContext, useEffect } from 'react'
 
 import { useWeb3Modal } from '@web3modal/wagmi/react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import Button from '@/components/general/Button'
 import IntroWallet from '@/components/general/Icon/IntroWallet'
 import IntroContent from '@/components/general/IntroContent'
+import Text from '@/components/general/Text'
 import TransitionDiv from '@/components/general/TransitionDiv'
 import Sidebar from '@/components/layout/Sidebar'
 import W3iContext from '@/contexts/W3iContext/context'
@@ -55,6 +56,19 @@ const Login: React.FC = () => {
           }
           icon={<IntroWallet />}
         />
+        <div className="Main__footer">
+          <Text className="Main__footer__title" variant="small-400">
+            Learn more at
+          </Text>
+          <Link
+            className="Main__footer__link"
+            to="https://web3inbox.com"
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            <Text variant="small-400">web3inbox.com</Text>
+          </Link>
+        </div>
       </main>
     </TransitionDiv>
   )

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -9,6 +9,7 @@ import IntroContent from '@/components/general/IntroContent'
 import Text from '@/components/general/Text'
 import TransitionDiv from '@/components/general/TransitionDiv'
 import Sidebar from '@/components/layout/Sidebar'
+import { web3InboxURLs } from '@/constants/navigation'
 import W3iContext from '@/contexts/W3iContext/context'
 
 import './Login.scss'
@@ -62,7 +63,7 @@ const Login: React.FC = () => {
           </Text>
           <Link
             className="Main__footer__link"
-            to="https://web3inbox.com"
+            to={web3InboxURLs.website}
             target="_blank"
             rel="noreferrer noopener"
           >


### PR DESCRIPTION
# Description

Add web3inbox.com redirections to login and PWA modals for users to learn more incase they are directly opened to the app.web3inbox.com.

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Fixes/Resolves (Optional)

Closes https://github.com/WalletConnect/web3inbox/issues/331

# Examples/Screenshots (Optional)

<img width="300" alt="Screenshot 2024-01-15 at 14 49 01" src="https://github.com/WalletConnect/web3inbox/assets/19428358/b31f0f33-2f6e-4ccf-ac19-14748192ed00">

<img width="300" alt="Screenshot 2024-01-15 at 14 49 09" src="https://github.com/WalletConnect/web3inbox/assets/19428358/237b2513-a815-40f4-89b3-3aeabeb45acd">


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Please include any additional information that may be useful for the reviewer.
