### PR TITLE
feat: add change browser modal

### DIFF
--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo } from 'react'
+import { useContext, useEffect } from 'react'
 
 import { useWeb3Modal } from '@web3modal/wagmi/react'
 import { AnimatePresence } from 'framer-motion'
@@ -16,7 +16,7 @@ import {
   checkIfNotificationModalClosed,
   notificationsEnabledInBrowser
 } from '@/utils/notifications'
-import { isAppleMobile, isMobileButNotInstalledOnHomeScreen, isSafari } from '@/utils/pwa'
+import { isAppleMobile, isMobileButNotInstalledOnHomeScreen, isNonSafari } from '@/utils/pwa'
 import { notificationPwaModalService, signatureModalService } from '@/utils/store'
 import { isMobile } from '@/utils/ui'
 
@@ -35,7 +35,7 @@ export const Modals = () => {
 
   const notificationModalClosed = checkIfNotificationModalClosed()
   const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
-  const shouldShowChangeBrowserModal = isAppleMobile ? !isSafari : false
+  const shouldShowChangeBrowserModal = isAppleMobile ? isNonSafari : false
   const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen && !shouldShowChangeBrowserModal
   const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal
   const shouldShowUnsubscribeModalOpen = isUnsubscribeModalOpen && !shouldShowChangeBrowserModal

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -16,7 +16,7 @@ import {
   checkIfNotificationModalClosed,
   notificationsEnabledInBrowser
 } from '@/utils/notifications'
-import { isChrome, isIOS, isMobileButNotInstalledOnHomeScreen } from '@/utils/pwa'
+import { isAppleMobile, isMobileButNotInstalledOnHomeScreen, isSafari } from '@/utils/pwa'
 import { notificationPwaModalService, signatureModalService } from '@/utils/store'
 import { isMobile } from '@/utils/ui'
 
@@ -35,8 +35,8 @@ export const Modals = () => {
 
   const notificationModalClosed = checkIfNotificationModalClosed()
   const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
-  const shouldShowChangeBrowserModal = isIOS() && isChrome()
-  const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen() && !shouldShowChangeBrowserModal
+  const shouldShowChangeBrowserModal = isAppleMobile ? !isSafari : false
+  const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen && !shouldShowChangeBrowserModal
   const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal
   const shouldShowUnsubscribeModalOpen = isUnsubscribeModalOpen && !shouldShowChangeBrowserModal
   const shouldShowPreferencesModalOpen = isPreferencesModalOpen && !shouldShowChangeBrowserModal
@@ -44,7 +44,7 @@ export const Modals = () => {
   const shouldShowNotificationModal =
     notificationsEnabledInBrowser() &&
     !explicitlyDeniedOnDesktop &&
-    !isMobileButNotInstalledOnHomeScreen() &&
+    !isMobileButNotInstalledOnHomeScreen &&
     !notificationsEnabled &&
     Boolean(notifyRegisteredKey) &&
     !isSignatureModalOpen &&

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence } from 'framer-motion'
 
 import { PreferencesModal } from '@/components/notifications/NotificationsLayout/PreferencesModal'
 import { UnsubscribeModal } from '@/components/notifications/NotificationsLayout/UnsubscribeModal'
+import ChangeBrowserModal from '@/components/utils/ChangeBrowserModal'
 import NotificationPwaModal from '@/components/utils/NotificationPwaModal'
 import PwaModal from '@/components/utils/PwaModal'
 import W3iContext from '@/contexts/W3iContext/context'
@@ -15,7 +16,7 @@ import {
   checkIfNotificationModalClosed,
   notificationsEnabledInBrowser
 } from '@/utils/notifications'
-import { isMobileButNotInstalledOnHomeScreen } from '@/utils/pwa'
+import { isChrome, isIOS, isMobileButNotInstalledOnHomeScreen } from '@/utils/pwa'
 import { notificationPwaModalService, signatureModalService } from '@/utils/store'
 import { isMobile } from '@/utils/ui'
 
@@ -34,6 +35,11 @@ export const Modals = () => {
 
   const notificationModalClosed = checkIfNotificationModalClosed()
   const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
+  const shouldShowChangeBrowserModal = isIOS() && isChrome()
+  const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen() && !shouldShowChangeBrowserModal
+  const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal
+  const shouldShowUnsubscribeModalOpen = isUnsubscribeModalOpen && !shouldShowChangeBrowserModal
+  const shouldShowPreferencesModalOpen = isPreferencesModalOpen && !shouldShowChangeBrowserModal
 
   const shouldShowNotificationModal =
     notificationsEnabledInBrowser() &&
@@ -42,7 +48,8 @@ export const Modals = () => {
     !notificationsEnabled &&
     Boolean(notifyRegisteredKey) &&
     !isSignatureModalOpen &&
-    !notificationModalClosed
+    !notificationModalClosed &&
+    !shouldShowChangeBrowserModal
 
   useEffect(() => {
     const notifySignatureRequired = Boolean(notifyRegisterMessage) && !notifyRegisteredKey
@@ -67,17 +74,19 @@ export const Modals = () => {
 
   return (
     <AnimatePresence mode="popLayout">
-      {isUnsubscribeModalOpen && <UnsubscribeModal />}
+      {shouldShowUnsubscribeModalOpen && <UnsubscribeModal />}
 
-      {isPreferencesModalOpen && <PreferencesModal />}
+      {shouldShowPreferencesModalOpen && <PreferencesModal />}
 
-      {isSignatureModalOpen && (
+      {shouldShowSignatureModal && (
         <SignatureModal message={notifyRegisterMessage ?? ''} sender={'notify'} />
       )}
 
-      {isMobileButNotInstalledOnHomeScreen() && <PwaModal />}
+      {shouldShowPWAModal && <PwaModal />}
 
       {isNotificationPwaModalOpen && <NotificationPwaModal />}
+
+      {shouldShowChangeBrowserModal && <ChangeBrowserModal />}
     </AnimatePresence>
   )
 }

--- a/src/components/utils/ChangeBrowserModal/ChangeBrowserModal.scss
+++ b/src/components/utils/ChangeBrowserModal/ChangeBrowserModal.scss
@@ -1,0 +1,54 @@
+.ChangeBrowserModal {
+  padding: 3em;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
+  gap: 2em;
+  position: relative;
+
+  &__close-button {
+    svg {
+      color: var(--fg-color-3);
+    }
+  }
+
+  &__header {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    align-items: center;
+  }
+
+  &__background {
+    position: absolute;
+    z-index: -999;
+    top: -50%;
+    left: -50%;
+  }
+
+  &__icon {
+    display: block;
+    width: 3em;
+    background: white;
+    width: 4em;
+    height: 4em;
+    display: grid;
+    place-items: center;
+    padding: 0.75em;
+    border-radius: 13px;
+    box-shadow: 0px 8px 32px 17.5px hsla(0, 0%, 0%, 0.12);
+  }
+
+  &__warning {
+    color: var(--error-color-1);
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    align-items: center;
+    text-align: center;
+  }
+}

--- a/src/components/utils/ChangeBrowserModal/index.tsx
+++ b/src/components/utils/ChangeBrowserModal/index.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+
+import BackgroundImage from '@/assets/IntroBackground.png'
+import { Modal } from '@/components/general/Modal/Modal'
+import Text from '@/components/general/Text'
+import { pwaModalService } from '@/utils/store'
+
+import './ChangeBrowserModal.scss'
+
+export const ChangeBrowserModal: React.FC = () => {
+  return (
+    <Modal onCloseModal={pwaModalService.closeModal}>
+      <div className="ChangeBrowserModal">
+        <div className="ChangeBrowserModal__background">
+          <img src={BackgroundImage} />
+        </div>
+        <div className="ChangeBrowserModal__icon">
+          <img alt="Web3Inbox icon" className="wc-icon" src="/icon.png" />
+        </div>
+        <Text variant={'large-500'}>Change Browser</Text>
+        <div className="ChangeBrowserModal__content">
+          <Text variant="small-500">
+            To install the app, you need to add this to your home screen.
+          </Text>
+          <Text variant="small-500">
+            Please open <span>app.web3inbox.com</span> in Safari and follow the instructions.
+          </Text>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default ChangeBrowserModal

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -61,13 +61,6 @@ export const PwaModal: React.FC = () => {
         </div>
         <div className="PwaModal__header">
           <Text variant={'large-500'}>Install PWA</Text>
-          <Button
-            onClick={() => {
-              navigator.clipboard.writeText(JSON.stringify(navigator.userAgent))
-            }}
-          >
-            copy navigator
-          </Button>
         </div>
         <div className="PwaModal__description">
           <Text variant="small-500">

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -4,11 +4,13 @@ import { detect } from 'detect-browser'
 import { Link } from 'react-router-dom'
 
 import BackgroundImage from '@/assets/IntroBackground.png'
+import Button from '@/components/general/Button'
 import AndroidShareIcon from '@/components/general/Icon/AndroidShare'
 import IShareIcon from '@/components/general/Icon/IShare'
 import { Modal } from '@/components/general/Modal/Modal'
 import Text from '@/components/general/Text'
 import { web3InboxURLs } from '@/constants/navigation'
+import { isAppleMobile } from '@/utils/pwa'
 import { pwaModalService } from '@/utils/store'
 
 import './PwaModal.scss'
@@ -58,7 +60,14 @@ export const PwaModal: React.FC = () => {
           <img alt="Web3Inbox icon" className="wc-icon" src="/icon.png" />
         </div>
         <div className="PwaModal__header">
-          <Text variant={'large-500'}>Install Web3Inbox</Text>
+          <Text variant={'large-500'}>Install PWA</Text>
+          <Button
+            onClick={() => {
+              navigator.clipboard.writeText(JSON.stringify(navigator.userAgent))
+            }}
+          >
+            copy navigator
+          </Button>
         </div>
         <div className="PwaModal__description">
           <Text variant="small-500">
@@ -71,6 +80,13 @@ export const PwaModal: React.FC = () => {
           <span className="PwaModal__share-icon">{getMobilePlatformIcon()}</span>
           <Text variant="small-500"> and “{getPlatformInstallText()}”</Text>
         </div>
+        {isAppleMobile ? (
+          <div className="PwaModal__footer">
+            <Text className="PwaModal__footer__title" variant="small-400">
+              Cannot see the option? Make sure you're using Safari.
+            </Text>
+          </div>
+        ) : null}
         <div className="PwaModal__footer">
           <Text className="PwaModal__footer__title" variant="small-400">
             Learn more at&nbsp;

--- a/src/components/utils/PwaModal/index.tsx
+++ b/src/components/utils/PwaModal/index.tsx
@@ -4,13 +4,11 @@ import { detect } from 'detect-browser'
 import { Link } from 'react-router-dom'
 
 import BackgroundImage from '@/assets/IntroBackground.png'
-import Button from '@/components/general/Button'
 import AndroidShareIcon from '@/components/general/Icon/AndroidShare'
 import IShareIcon from '@/components/general/Icon/IShare'
 import { Modal } from '@/components/general/Modal/Modal'
 import Text from '@/components/general/Text'
 import { web3InboxURLs } from '@/constants/navigation'
-import { isAppleMobile } from '@/utils/pwa'
 import { pwaModalService } from '@/utils/store'
 
 import './PwaModal.scss'
@@ -73,13 +71,6 @@ export const PwaModal: React.FC = () => {
           <span className="PwaModal__share-icon">{getMobilePlatformIcon()}</span>
           <Text variant="small-500"> and “{getPlatformInstallText()}”</Text>
         </div>
-        {isAppleMobile ? (
-          <div className="PwaModal__footer">
-            <Text className="PwaModal__footer__title" variant="small-400">
-              Cannot see the option? Make sure you're using Safari.
-            </Text>
-          </div>
-        ) : null}
         <div className="PwaModal__footer">
           <Text className="PwaModal__footer__title" variant="small-400">
             Learn more at&nbsp;

--- a/src/utils/pwa.ts
+++ b/src/utils/pwa.ts
@@ -4,15 +4,14 @@ export const isMobileBrowser = /iPhone|iPad|iPod|Android/i.test(navigator.userAg
 
 export const isAppleMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
-/**
- * vendor is deprecated but it's the only way to detect if the browser is belongs to Apple product (Safari)
- * There are variety of browsers that are based on Chromium (Chrome, Arc, Brave, etc.) but `navigator` object doesn't provide a unique way to detect them.
- * `userAgent` or other fields doesn't give us ability to check if it's Safari or not.
- * So, we need to check the vendor to make sure that the browser is Safari to make conditional rendering.
- * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
- */
-const isAppleVendor = /Apple Computer, Inc./i.test(navigator.vendor)
+export const isNonSafari = /CriOS|FxiOS/i.test(navigator.userAgent)
 
-export const isSafari = isAppleVendor && navigator.userAgent.match(/Safari/i)
+/**
+ * It's not possible to detect Safari on iOS. `navigator` object doesn't have enough information to detect if the running browser is exactly Safari.
+ * There are several fields like `vendor` (deprecated), `userAgent`, `userAgentData`. But these values can mislead us since they can return the same values for different browsers.
+ * Instead of detecting Safari and doing conditional renderings with this value, prefer different solution.
+ * Tested mobile browsers: Safari, Chrome, Firefox, Arc, Brave
+ */
+export const isSafari = isAppleMobile && navigator.userAgent.match(/Safari/i)
 
 export const isMobileButNotInstalledOnHomeScreen = isMobileBrowser && !isInstalledOnHomeScreen

--- a/src/utils/pwa.ts
+++ b/src/utils/pwa.ts
@@ -1,21 +1,18 @@
-import { detect } from 'detect-browser'
+export const isInstalledOnHomeScreen = window.matchMedia('(display-mode: standalone)').matches
 
-const browser = detect()
+export const isMobileBrowser = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
 
-export const isInstalledOnHomescreen = () => {
-  // on Android and iOS, display mode is set to
-  // standalone when the app is opened from home screen
-  const displayIsStandalone = window.matchMedia('(display-mode: standalone)').matches
+export const isAppleMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
-  return displayIsStandalone
-}
+/**
+ * vendor is deprecated but it's the only way to detect if the browser is belongs to Apple product (Safari)
+ * There are variety of browsers that are based on Chromium (Chrome, Arc, Brave, etc.) but `navigator` object doesn't provide a unique way to detect them.
+ * `userAgent` or other fields doesn't give us ability to check if it's Safari or not.
+ * So, we need to check the vendor to make sure that the browser is Safari to make conditional rendering.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
+ */
+const isAppleVendor = /Apple Computer, Inc./i.test(navigator.vendor)
 
-export const isMobileBrowser = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+export const isSafari = isAppleVendor && navigator.userAgent.match(/Safari/i)
 
-export const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent)
-
-export const isChrome = () =>
-  browser?.name ? /chrome|crios|edge-chromium/i.test(browser?.name) : false
-
-export const isMobileButNotInstalledOnHomeScreen = () =>
-  isMobileBrowser() && !isInstalledOnHomescreen()
+export const isMobileButNotInstalledOnHomeScreen = isMobileBrowser && !isInstalledOnHomeScreen

--- a/src/utils/pwa.ts
+++ b/src/utils/pwa.ts
@@ -1,3 +1,7 @@
+import { detect } from 'detect-browser'
+
+const browser = detect()
+
 export const isInstalledOnHomescreen = () => {
   // on Android and iOS, display mode is set to
   // standalone when the app is opened from home screen
@@ -7,6 +11,11 @@ export const isInstalledOnHomescreen = () => {
 }
 
 export const isMobileBrowser = () => /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+
+export const isIOS = () => /iPhone|iPad|iPod/i.test(navigator.userAgent)
+
+export const isChrome = () =>
+  browser?.name ? /chrome|crios|edge-chromium/i.test(browser?.name) : false
 
 export const isMobileButNotInstalledOnHomeScreen = () =>
   isMobileBrowser() && !isInstalledOnHomescreen()

--- a/src/utils/pwa.ts
+++ b/src/utils/pwa.ts
@@ -4,14 +4,12 @@ export const isMobileBrowser = /iPhone|iPad|iPod|Android/i.test(navigator.userAg
 
 export const isAppleMobile = /iPhone|iPad|iPod/i.test(navigator.userAgent)
 
-export const isNonSafari = /CriOS|FxiOS/i.test(navigator.userAgent)
-
 /**
- * It's not possible to detect Safari on iOS. `navigator` object doesn't have enough information to detect if the running browser is exactly Safari.
- * There are several fields like `vendor` (deprecated), `userAgent`, `userAgentData`. But these values can mislead us since they can return the same values for different browsers.
- * Instead of detecting Safari and doing conditional renderings with this value, prefer different solution.
- * Tested mobile browsers: Safari, Chrome, Firefox, Arc, Brave
+ * WARN: Browser check can be tricky and not reliable at some cases.
+ * Some non-Safari browsers can return the same `userAgent` value as Safari, so it might not be quite possible to detect if the browser is Safari or not.
+ * There are several fields like `vendor` (deprecated), `userAgent`, `userAgentData`. Some of these are deprecated and some are returning similar values across different browsers like `userAgent`.
+ * So be aware that is not perfect solution.
  */
-export const isSafari = isAppleMobile && navigator.userAgent.match(/Safari/i)
+export const isNonSafari = /CriOS|FxiOS/i.test(navigator.userAgent)
 
 export const isMobileButNotInstalledOnHomeScreen = isMobileBrowser && !isInstalledOnHomeScreen


### PR DESCRIPTION
# Description

iOS Chromium browsers don't have `Add to Home Screen` functionality. For the iOS users, we should redirect them to Safari instead. Added change browser modal and refactored conditions for the other modals to make sure that mobile Chroimum users should redirected to Safari first.

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Fixes/Resolves (Optional)


# Examples/Screenshots (Optional)

<img width="512" alt="Screenshot 2024-01-15 at 15 26 44" src="https://github.com/WalletConnect/web3inbox/assets/19428358/a006e175-0eb8-489d-a76e-2ecf47a51671">

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

Closes https://github.com/WalletConnect/web3inbox-planning/issues/48

