### PR TITLE
fix: ensure useEffect does not spam `closeWeb3Modal` + close event

### DIFF
--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -35,7 +35,8 @@ export const Modals = () => {
   const notificationsEnabled = useNotificationPermissionState()
 
   const notificationModalClosed = checkIfNotificationModalClosed()
-  const explicitlyDeniedOnDesktop = !isMobile() && window.Notification.permission === 'denied'
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
   const shouldShowChangeBrowserModal = isAppleMobile ? isNonSafari : false
   const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen && !shouldShowChangeBrowserModal
   const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect } from 'react'
 
-import { useWeb3Modal } from '@web3modal/wagmi/react'
+import { useWeb3Modal, useWeb3ModalState } from '@web3modal/wagmi/react'
 import { AnimatePresence } from 'framer-motion'
 
 import { PreferencesModal } from '@/components/notifications/NotificationsLayout/PreferencesModal'
@@ -28,13 +28,14 @@ export const Modals = () => {
     isNotificationPwaModalOpen
   } = useModals()
   const { close: closeWeb3Modal } = useWeb3Modal()
+  const { open: isWeb3ModalOpen } = useWeb3ModalState()
 
   const { notifyRegisterMessage, notifyRegisteredKey, userPubkey } = useContext(W3iContext)
 
   const notificationsEnabled = useNotificationPermissionState()
 
   const notificationModalClosed = checkIfNotificationModalClosed()
-  const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
+  const explicitlyDeniedOnDesktop = !isMobile() && window.Notification.permission === 'denied'
   const shouldShowChangeBrowserModal = isAppleMobile ? isNonSafari : false
   const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen && !shouldShowChangeBrowserModal
   const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal
@@ -54,12 +55,22 @@ export const Modals = () => {
   useEffect(() => {
     const notifySignatureRequired = Boolean(notifyRegisterMessage) && !notifyRegisteredKey
     if (userPubkey && notifySignatureRequired) {
-      closeWeb3Modal() // close web3modal in case user is switching accounts
+      if (isWeb3ModalOpen) {
+        // Close web3modal in case user is switching accounts
+        closeWeb3Modal()
+      }
       signatureModalService.openModal()
     } else {
       signatureModalService.closeModal()
     }
-  }, [userPubkey, closeWeb3Modal, notifyRegisteredKey, notifyRegisterMessage])
+  }, [
+    userPubkey,
+    closeWeb3Modal,
+    notifyRegisteredKey,
+    notifyRegisterMessage,
+    isWeb3ModalOpen,
+    signatureModalService
+  ])
 
   useEffect(() => {
     // Create an artificial delay to prevent modals being spammed one after the other


### PR DESCRIPTION
# Description

- Bug: This `useEffect` is called in a loop for the duration of the signature modal being open
	- It was also calling `closeWeb3Modal` unchecked i.e. even if w3m was already in a closed state
	- This was causing our analytics endpoint to be spammed with `MODAL_CLOSE` events **which could lead to unintentional request floods from users that leave the app in this state.**
- **This patch ensures we first check `open: boolean` state for w3m before explicitly calling `closeWeb3Modal`**
- **This patch does not root cause why this useEffect goes into a loop once the signature modal opens, this is TBD.**

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Examples/Screenshots (Optional)

## Reproduction

1. Go to app.web3inbox.com (or a preview that has w3m analytics enabled)
2. Use a fresh account or reset client state to ensure you get the secondary "Sign notify message" popup after w3m connect
3. Observe network tab after initial w3m connect; spamming the `pulse.walletconnect.com/e` endpoint with `MODAL_CLOSE` events (see screenshot)


## Screenshots

<img width="1470" alt="Screenshot 2024-01-16 at 12 10 54" src="https://github.com/WalletConnect/web3inbox/assets/8663099/ec8f757e-adc8-4024-9968-8faa6f312c90">



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

