### PR TITLE
feat: reregister if no registration while subscribing

### DIFF
--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -47,7 +47,7 @@ export const COMING_SOON_PROJECTS: Array<INotifyApp> = [
     id: 'avive',
     name: 'Avive',
     description:
-      'One of the world\'s largest UBI & DePin Projects, with over 9 million worldwide users.',
+      "One of the world's largest UBI & DePin Projects, with over 9 million worldwide users.",
     url: 'https://www.avive.world',
     isComingSoon: true,
     isVerified: false,
@@ -57,8 +57,7 @@ export const COMING_SOON_PROJECTS: Array<INotifyApp> = [
   {
     id: 'maverick',
     name: 'Maverick Protocol',
-    description:
-      'Maverick Protocol is a leading provider of smart contract solutions in DeFi.',
+    description: 'Maverick Protocol is a leading provider of smart contract solutions in DeFi.',
     url: 'https://app.mav.xyz',
     isComingSoon: true,
     isVerified: false,
@@ -68,8 +67,7 @@ export const COMING_SOON_PROJECTS: Array<INotifyApp> = [
   {
     id: 'loopring-pro',
     name: 'Loopring Pro',
-    description:
-      'Explore the Loopring DEX, Earn, and NFT Management.',
+    description: 'Explore the Loopring DEX, Earn, and NFT Management.',
     url: 'https://loopring.io/#/pro',
     isComingSoon: true,
     isVerified: false,
@@ -79,8 +77,7 @@ export const COMING_SOON_PROJECTS: Array<INotifyApp> = [
   {
     id: 'loopring-earn',
     name: 'Loopring Earn',
-    description:
-      'Access the most innovative structural products brought to the DeFi world.',
+    description: 'Access the most innovative structural products brought to the DeFi world.',
     url: 'https://earn.loopring.io/',
     isComingSoon: true,
     isVerified: false,

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -154,20 +154,20 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
     })
 
     const notifyReregisterSub = notifyClient.observe('notify_reregister', {
-      next: (params) => {
-	handleRegistration(params.userPubkey).then(() => {
-	  switch(params.nextAction.type) {
-	    case "subscribe":
-	      notifyClient.subscribe(params.nextAction.params)
-	      break;
-	    case "deleteSubscription":
-	      notifyClient.deleteSubscription(params.nextAction.params)
-	      break;
-	    case "update":
-	      notifyClient.update(params.nextAction.params)
-	      break;
-	  }
-	})
+      next: params => {
+        handleRegistration(params.userPubkey).then(() => {
+          switch (params.nextAction.type) {
+            case 'subscribe':
+              notifyClient.subscribe(params.nextAction.params)
+              break
+            case 'deleteSubscription':
+              notifyClient.deleteSubscription(params.nextAction.params)
+              break
+            case 'update':
+              notifyClient.update(params.nextAction.params)
+              break
+          }
+        })
       }
     })
 

--- a/src/contexts/W3iContext/hooks/notifyHooks.ts
+++ b/src/contexts/W3iContext/hooks/notifyHooks.ts
@@ -153,6 +153,24 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
       }
     })
 
+    const notifyReregisterSub = notifyClient.observe('notify_reregister', {
+      next: (params) => {
+	handleRegistration(params.userPubkey).then(() => {
+	  switch(params.nextAction.type) {
+	    case "subscribe":
+	      notifyClient.subscribe(params.nextAction.params)
+	      break;
+	    case "deleteSubscription":
+	      notifyClient.deleteSubscription(params.nextAction.params)
+	      break;
+	    case "update":
+	      notifyClient.update(params.nextAction.params)
+	      break;
+	  }
+	})
+      }
+    })
+
     const syncUpdateSub = notifyClient.observe('sync_update', {
       next: refreshNotifyState
     })
@@ -165,6 +183,7 @@ export const useNotifyState = (w3iProxy: Web3InboxProxy, proxyReady: boolean) =>
       notifySubsChanged.unsubscribe()
       notifySignatureRequestedSub.unsubscribe()
       notifySignatureRequestCancelledSub.unsubscribe()
+      notifyReregisterSub.unsubscribe()
     }
   }, [notifyClient, refreshNotifyState, setWatchSubscriptionsComplete])
 

--- a/src/w3iProxy/listenerTypes.ts
+++ b/src/w3iProxy/listenerTypes.ts
@@ -21,12 +21,12 @@ export interface ChatFacadeEvents {
   sync_update: never
 }
 
-type NextAction<T extends "subscribe" | "update" | "deleteSubscription"> = {
-  type: T,
+type NextAction<T extends 'subscribe' | 'update' | 'deleteSubscription'> = {
+  type: T
   params: Parameters<NotifyClient[T]>[0]
 }
 
-type NextActions = NextAction<"subscribe"> | NextAction<"update"> | NextAction<"deleteSubscription">
+type NextActions = NextAction<'subscribe'> | NextAction<'update'> | NextAction<'deleteSubscription'>
 
 export interface NotifyFacadeEvents {
   notify_message: NotifyClientTypes.EventArguments['notify_message']
@@ -36,6 +36,6 @@ export interface NotifyFacadeEvents {
   notify_subscriptions_changed: NotifyClientTypes.EventArguments['notify_subscriptions_changed']
   notify_signature_requested: { message: string }
   notify_signature_request_cancelled: never
-  notify_reregister: { userPubkey: string, nextAction: NextActions}
+  notify_reregister: { userPubkey: string; nextAction: NextActions }
   sync_update: never
 }

--- a/src/w3iProxy/listenerTypes.ts
+++ b/src/w3iProxy/listenerTypes.ts
@@ -1,4 +1,4 @@
-import type { NotifyClientTypes } from '@walletconnect/notify-client'
+import type { NotifyClient, NotifyClientTypes } from '@walletconnect/notify-client'
 
 import type { ChatClientTypes } from './chatProviders/types'
 
@@ -21,6 +21,13 @@ export interface ChatFacadeEvents {
   sync_update: never
 }
 
+type NextAction<T extends "subscribe" | "update" | "deleteSubscription"> = {
+  type: T,
+  params: Parameters<NotifyClient[T]>[0]
+}
+
+type NextActions = NextAction<"subscribe"> | NextAction<"update"> | NextAction<"deleteSubscription">
+
 export interface NotifyFacadeEvents {
   notify_message: NotifyClientTypes.EventArguments['notify_message']
   notify_subscription: NotifyClientTypes.EventArguments['notify_subscription']
@@ -29,5 +36,6 @@ export interface NotifyFacadeEvents {
   notify_subscriptions_changed: NotifyClientTypes.EventArguments['notify_subscriptions_changed']
   notify_signature_requested: { message: string }
   notify_signature_request_cancelled: never
+  notify_reregister: { userPubkey: string, nextAction: NextActions}
   sync_update: never
 }

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -208,9 +208,13 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       ? this.notifyClient.subscriptions.get(params.topic).account
       : ''
 
-    if (
-      !this.notifyClient.isRegistered({ account, domain: window.location.hostname, allApps: true })
-    ) {
+     const isRegistered = this.notifyClient.isRegistered({
+      account,
+      domain: window.location.hostname,
+      allApps: true
+    })
+
+    if (!isRegistered) {
       this.emitter.emit('notify_reregister', {
         userPubkey: account,
         nextAction: {

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -53,11 +53,6 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       this.emitter.emit('sync_update', {})
     })
 
-    // @ts-ignore
-    window.forceUnregister = (account:string) => {
-      this.unregister({account})
-    }
-
     // Ensure we have a registration with echo (if we need it)
     this.ensureEchoRegistration()
     updateSymkeyState()

--- a/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
+++ b/src/w3iProxy/notifyProviders/internalNotifyProvider.ts
@@ -163,12 +163,21 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       throw new Error(this.formatClientRelatedError('subscribe'))
     }
 
-    if(!this.notifyClient.isRegistered({ account: params.account, domain: window.location.hostname, allApps: true })) {
-      this.emitter.emit("notify_reregister", {userPubkey: params.account, nextAction: {
-	type: "subscribe",
-	params,
-      }})
-      return false;
+    if (
+      !this.notifyClient.isRegistered({
+        account: params.account,
+        domain: window.location.hostname,
+        allApps: true
+      })
+    ) {
+      this.emitter.emit('notify_reregister', {
+        userPubkey: params.account,
+        nextAction: {
+          type: 'subscribe',
+          params
+        }
+      })
+      return false
     }
 
     let subscribed: boolean = false
@@ -195,15 +204,21 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       throw new Error(this.formatClientRelatedError('update'))
     }
 
-    const account = this.notifyClient.subscriptions.keys.includes(params.topic)?
-      this.notifyClient.subscriptions.get(params.topic).account : ""
+    const account = this.notifyClient.subscriptions.keys.includes(params.topic)
+      ? this.notifyClient.subscriptions.get(params.topic).account
+      : ''
 
-    if(!this.notifyClient.isRegistered({ account, domain: window.location.hostname, allApps: true })) {
-      this.emitter.emit("notify_reregister", {userPubkey: account, nextAction: {
-	type: "update",
-	params
-      }})
-      return false;
+    if (
+      !this.notifyClient.isRegistered({ account, domain: window.location.hostname, allApps: true })
+    ) {
+      this.emitter.emit('notify_reregister', {
+        userPubkey: account,
+        nextAction: {
+          type: 'update',
+          params
+        }
+      })
+      return false
     }
 
     const updated = await this.notifyClient.update(params)
@@ -216,15 +231,21 @@ export default class InternalNotifyProvider implements W3iNotifyProvider {
       throw new Error(this.formatClientRelatedError('deleteSubscription'))
     }
 
-    const account = this.notifyClient.subscriptions.keys.includes(params.topic)?
-      this.notifyClient.subscriptions.get(params.topic).account : ""
+    const account = this.notifyClient.subscriptions.keys.includes(params.topic)
+      ? this.notifyClient.subscriptions.get(params.topic).account
+      : ''
 
-    if(!this.notifyClient.isRegistered({ account, domain: window.location.hostname, allApps: true })) {
-      this.emitter.emit("notify_reregister", {userPubkey: account, nextAction: {
-	type: "deleteSubscription",
-	params
-      }})
-      return;
+    if (
+      !this.notifyClient.isRegistered({ account, domain: window.location.hostname, allApps: true })
+    ) {
+      this.emitter.emit('notify_reregister', {
+        userPubkey: account,
+        nextAction: {
+          type: 'deleteSubscription',
+          params
+        }
+      })
+      return
     }
 
     return this.notifyClient.deleteSubscription(params)


### PR DESCRIPTION
# Description

- issue registration in case someone `subscribe`s, `update`s or `deleteSubscription`s
- issue the action they tried to perform once again after successful registration automatically
# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

Resolves sentry issue: https://walletconnect.sentry.io/issues/4870845805/events/572bb5d5048d40e6ad069ef2df647a9a/?project=4505754150043648

# Tested
Tested via manually issueing unregister using the following addition in `internalNotifyProvider`

```
    // @ts-ignore
    window.forceUnregister = (account:string) => {
      this.unregister({account})
   }
-
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules