### PR TITLE
Test/e2e phase 1

### DIFF
--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -29,8 +29,8 @@ jobs:
         env:
           VITE_PROJECT_ID: ${{ secrets.VITE_DEV_PROJECT_ID }}
           VITE_EXPLORER_API_URL: ${{ secrets.VITE_EXPLORER_API_URL }}
-          TEST_DAPP_ID: ${{ secrets.TEST_DAPP_ID }}
-          TEST_DAPP_SECRET: ${{ secrets.TEST_DAPP_SECRET }}
+          TEST_DAPP_PROJECT_ID: ${{ secrets.TEST_DAPP_PROJECT_ID }}
+          TEST_DAPP_PROJECT_SECRET: ${{ secrets.TEST_DAPP_PROJECT_SECRET }}
           VITE_CI: true
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           VITE_PROJECT_ID: ${{ secrets.VITE_DEV_PROJECT_ID }}
           VITE_EXPLORER_API_URL: ${{ secrets.VITE_EXPLORER_API_URL }}
+          TEST_DAPP_ID: ${{ secrets.TEST_DAPP_ID }}
+          TEST_DAPP_SECRET: ${{ secrets.TEST_DAPP_SECRET }}
           VITE_CI: true
       - uses: actions/upload-artifact@v3
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,10 +37,6 @@ export default defineConfig({
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] }
     },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] }
-    }
   ],
 
   /* Run your local dev server before starting the tests */

--- a/tests/shared/constants/index.ts
+++ b/tests/shared/constants/index.ts
@@ -14,7 +14,7 @@ export const CUSTOM_TEST_DAPP = {
   icons: ["https://i.imgur.com/q9QDRXc.png"],
   name: "Notify Swift Integration Tests Prod",
   appDomain: "wc-notify-swift-integration-tests-prod.pages.dev",
-  projectSecret: process.env['TEST_DAPP_SECRET'],
-  projectId: process.env['TEST_DAPP_ID'],
+  projectSecret: process.env['TEST_DAPP_PROJECT_SECRET'],
+  projectId: process.env['TEST_DAPP_PROJECT_ID'],
   messageType: "f173f231-a45c-4dc0-aa5d-956eb04f7360"
 } as const;

--- a/tests/shared/constants/index.ts
+++ b/tests/shared/constants/index.ts
@@ -8,3 +8,13 @@ export const DEFAULT_SESSION_PARAMS: SessionParams = {
   optAccounts: ['1', '2'],
   accept: true
 }
+
+export const CUSTOM_TEST_DAPP = {
+  description: "Test description",
+  icons: ["https://i.imgur.com/q9QDRXc.png"],
+  name: "Notify Swift Integration Tests Prod",
+  appDomain: "wc-notify-swift-integration-tests-prod.pages.dev",
+  projectSecret: process.env['TEST_DAPP_SECRET'],
+  projectId: process.env['TEST_DAPP_ID'],
+  messageType: "f173f231-a45c-4dc0-aa5d-956eb04f7360"
+} as const;

--- a/tests/shared/fixtures/fixture.ts
+++ b/tests/shared/fixtures/fixture.ts
@@ -2,11 +2,15 @@ import { test as base } from '@playwright/test'
 
 import { InboxPage } from '../pages/InboxPage'
 import { InboxValidator } from '../validators/ModalValidator'
+import { SettingsPage } from '../pages/SettingsPage'
+import { NotifyServer } from '../helpers/notifyServer'
 
 // Declare the types of fixtures to use
 export interface ModalFixture {
   inboxPage: InboxPage
   inboxValidator: InboxValidator
+  settingsPage: SettingsPage
+  notifyServer: NotifyServer
   library: string
 }
 
@@ -19,6 +23,16 @@ export const test = base.extend<ModalFixture>({
   inboxValidator: async ({ inboxPage }, use) => {
     const modalValidator = new InboxValidator(inboxPage.page)
     await use(modalValidator)
-  }
+  },
+  // Have to pass same page object to maintain state between pages
+  settingsPage: async({ inboxPage }, use) => {
+    const settingsPage = new SettingsPage(inboxPage.page)
+    settingsPage.load()
+    use(settingsPage)
+  },
+  notifyServer: async(_, use) => {
+    const notifyServer = new NotifyServer();
+    use(notifyServer)
+  },
 })
 export { expect } from '@playwright/test'

--- a/tests/shared/fixtures/fixture.ts
+++ b/tests/shared/fixtures/fixture.ts
@@ -1,23 +1,23 @@
 import { test as base } from '@playwright/test'
 
 import { InboxPage } from '../pages/InboxPage'
-import { ModalValidator } from '../validators/ModalValidator'
+import { InboxValidator } from '../validators/ModalValidator'
 
 // Declare the types of fixtures to use
 export interface ModalFixture {
   inboxPage: InboxPage
-  inboxValidator: ModalValidator
+  inboxValidator: InboxValidator
   library: string
 }
 
 export const test = base.extend<ModalFixture>({
   inboxPage: async ({ page }, use) => {
-    const modalPage = new ModalPage(page)
-    await modalPage.load()
-    await use(modalPage)
+    const inboxPage = new InboxPage(page)
+    await inboxPage.load()
+    await use(inboxPage)
   },
-  inboxValidator: async ({ modalPage }, use) => {
-    const modalValidator = new ModalValidator(modalPage.page)
+  inboxValidator: async ({ inboxPage }, use) => {
+    const modalValidator = new InboxValidator(inboxPage.page)
     await use(modalValidator)
   }
 })

--- a/tests/shared/fixtures/fixture.ts
+++ b/tests/shared/fixtures/fixture.ts
@@ -30,7 +30,7 @@ export const test = base.extend<ModalFixture>({
     settingsPage.load()
     use(settingsPage)
   },
-  notifyServer: async(_, use) => {
+  notifyServer: async({}, use) => {
     const notifyServer = new NotifyServer();
     use(notifyServer)
   },

--- a/tests/shared/fixtures/fixture.ts
+++ b/tests/shared/fixtures/fixture.ts
@@ -1,22 +1,22 @@
 import { test as base } from '@playwright/test'
 
-import { ModalPage } from '../pages/InboxPage'
+import { InboxPage } from '../pages/InboxPage'
 import { ModalValidator } from '../validators/ModalValidator'
 
 // Declare the types of fixtures to use
 export interface ModalFixture {
-  modalPage: ModalPage
-  modalValidator: ModalValidator
+  inboxPage: InboxPage
+  inboxValidator: ModalValidator
   library: string
 }
 
 export const test = base.extend<ModalFixture>({
-  modalPage: async ({ page }, use) => {
+  inboxPage: async ({ page }, use) => {
     const modalPage = new ModalPage(page)
     await modalPage.load()
     await use(modalPage)
   },
-  modalValidator: async ({ modalPage }, use) => {
+  inboxValidator: async ({ modalPage }, use) => {
     const modalValidator = new ModalValidator(modalPage.page)
     await use(modalValidator)
   }

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -46,6 +46,8 @@ export class NotifyServer {
       body: request
     })
 
+    console.log({fetchResultsStatus: fetchResults.status, fetchResults: await fetchResults.text()})
+
     expect(fetchResults.status).toEqual(200)
   }
 }

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -36,7 +36,6 @@ export class NotifyServer {
     const fetchUrl = `${this.notifyBaseUrl}/${projectId}/notify`
 
     const headers = new Headers({
-      
       Authorization: `Bearer ${projectSecret}`,
       "Content-Type": "application/json"
 

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -1,3 +1,5 @@
+import { expect } from "@playwright/test"
+
 export class NotifyServer {
   private notifyBaseUrl = "https://notify.walletconnect.com"
 
@@ -34,13 +36,27 @@ export class NotifyServer {
     const fetchUrl = `${this.notifyBaseUrl}/${projectId}/notify`
 
     const headers = new Headers({
+      
       Authorization: `Bearer ${projectSecret}`,
       "Content-Type": "application/json"
+
     })
 
-    await fetch(fetchUrl, {
-      headers,
-      body: request,
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(request));
+        controller.close(); // Close the stream after enqueueing the data
+      }
     })
+
+    const fetchResults = await fetch(fetchUrl, {
+      method: "POST",
+      headers,
+      body: stream,
+    })
+
+    console.log(">>>> FETCH", await fetchResults.text(), fetchResults.status)
+
+    expect(fetchResults.status).toEqual(200)
   }
 }

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -40,22 +40,11 @@ export class NotifyServer {
       "Content-Type": "application/json"
     })
 
-    const stream = new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(request));
-        controller.close(); // Close the stream after enqueueing the data
-      }
-    })
-
     const fetchResults = await fetch(fetchUrl, {
       method: "POST",
       headers,
-      // @ts-ignore
-      duplex: true,
-      body: stream,
+      body: request
     })
-
-    console.log(">>>> FETCH", await fetchResults.text(), fetchResults.status)
 
     expect(fetchResults.status).toEqual(200)
   }

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -38,7 +38,6 @@ export class NotifyServer {
     const headers = new Headers({
       Authorization: `Bearer ${projectSecret}`,
       "Content-Type": "application/json"
-
     })
 
     const stream = new ReadableStream({

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -1,0 +1,46 @@
+export class NotifyServer {
+  private notifyBaseUrl = "https://notify.walletconnect.com"
+
+  public async sendMessage({
+    projectId,
+    projectSecret,
+    accounts,
+    url,
+    title,
+    body,
+    icon,
+    type
+  }: {
+    projectId: string,
+    projectSecret: string,
+    accounts: string[]
+    title: string,
+    body: string,
+    icon: string,
+    url: string
+    type: string
+  }) {
+    const request = JSON.stringify({
+      accounts,
+      notification: {
+	title,
+	body,
+	icon,
+	url,
+	type
+      }
+    })
+
+    const fetchUrl = `${this.notifyBaseUrl}/${projectId}/notify`
+
+    const headers = new Headers({
+      Authorization: `Bearer ${projectSecret}`,
+      "Content-Type": "application/json"
+    })
+
+    await fetch(fetchUrl, {
+      headers,
+      body: request,
+    })
+  }
+}

--- a/tests/shared/helpers/notifyServer.ts
+++ b/tests/shared/helpers/notifyServer.ts
@@ -52,6 +52,8 @@ export class NotifyServer {
     const fetchResults = await fetch(fetchUrl, {
       method: "POST",
       headers,
+      // @ts-ignore
+      duplex: true,
       body: stream,
     })
 

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -12,7 +12,11 @@ export class InboxPage {
   }
 
   async load() {
-    await this.page.goto(this.baseURL)
+    await this.page.goto(`${this.baseURL}`)
+  }
+
+  async gotoDiscoverPage() {
+    await this.page.goto(`${this.baseURL}notifications/new-app`)
   }
 
   async copyConnectUriToClipboard() {
@@ -40,6 +44,15 @@ export class InboxPage {
     await this.page.locator('.NotificationPwaModal__close-button').first().click()
   }
 
+  async getAddress() {
+    await this.page.locator('.Avatar').click()
+    await this.page.locator('wui-icon[name=copy]').first().click();
+    const copiedAddress: string = this.page.evaluate('navigator.clipboard.readText()') as any
+    await this.page.locator('wui-icon[name=close]').first().click();
+
+    return copiedAddress;
+  }
+
   async subscribe(nth: number) {
     const appCard = this.page.locator('.AppCard__body').nth(nth)
     await appCard.locator('.AppCard__body__subscribe').click()
@@ -49,7 +62,6 @@ export class InboxPage {
     await appCard.locator('.AppCard__body__subscribed').getByText('Subscribed', { exact: false }).isVisible()
 
     await this.page.waitForTimeout(3000);
-
   }
 
   async navigateToNewSubscription(nth: number) {
@@ -105,7 +117,6 @@ export class InboxPage {
     expect(firstCheckBoxIsChecked).not.toEqual(firstCheckBoxIsCheckedAfterUpdating)
 
     await this.page.locator('.PreferencesModal__close').click();
-
   }
 
   async cancelSiwe() {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -49,11 +49,10 @@ export class InboxPage {
 
   async getAddress() {
     await this.page.locator('.Avatar').first().click()
-    await this.page.locator('wui-icon[name=copy]').first().click();
-    const copiedAddress: string = this.page.evaluate('navigator.clipboard.readText()') as any
+    const address = await this.page.locator('wui-avatar').getAttribute('alt')
     await this.page.locator('wui-icon[name=close]').first().click();
 
-    return copiedAddress;
+    return address;
   }
 
   async subscribe(nth: number) {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -12,7 +12,7 @@ export class InboxPage {
   }
 
   async load() {
-    await this.page.goto(`${this.baseURL}`)
+    await this.page.goto(this.baseURL)
   }
 
   async gotoDiscoverPage() {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -62,8 +62,6 @@ export class InboxPage {
     console.log({appCardText: await appCard.innerText()})
 
     await appCard.locator('.AppCard__body__subscribed').getByText('Subscribed', { exact: false }).isVisible()
-
-    await this.page.waitForTimeout(3000);
   }
 
   async navigateToNewSubscription(nth: number) {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -41,8 +41,15 @@ export class InboxPage {
   }
 
   async subscribe(nth: number) {
-    await this.page.locator('.AppCard__body > .AppCard__body__subscribe').nth(nth).click()
-    await this.page.getByText('Subscribed to', { exact: false }).isVisible()
+    const appCard = this.page.locator('.AppCard__body').nth(nth)
+    await appCard.locator('.AppCard__body__subscribe').click()
+
+    console.log({appCardText: await appCard.innerText()})
+
+    await appCard.locator('.AppCard__body__subscribed').getByText('Subscribed', { exact: false }).isVisible()
+
+    await this.page.waitForTimeout(3000);
+
   }
 
   async navigateToNewSubscription(nth: number) {
@@ -61,6 +68,17 @@ export class InboxPage {
     await this.page.getByRole('button', { name: 'Unsubscribe' }).nth(1).click()
     await this.page.getByText('Unsubscribed from', { exact: false }).isVisible()
     await this.page.waitForTimeout(2000)
+  }
+
+  async navigateToDappFromSidebar(nth: number) {
+    await this.page.locator('.AppSelector__notifications-link').nth(nth).click()
+  }
+
+  async countSubscribedDapps() {
+
+    const selected = await this.page.locator('AppSelector__list').all()
+    console.log({selected})
+    return (await this.page.locator('.AppSelector__notifications').count() - 1)
   }
 
   async updatePreferences() {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -2,7 +2,7 @@ import { type Locator, type Page, expect } from '@playwright/test'
 
 import { BASE_URL } from '../constants'
 
-export class ModalPage {
+export class InboxPage {
   private readonly baseURL = BASE_URL
 
   private readonly connectButton: Locator

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -59,8 +59,6 @@ export class InboxPage {
     const appCard = this.page.locator('.AppCard__body').nth(nth)
     await appCard.locator('.AppCard__body__subscribe').click()
 
-    console.log({appCardText: await appCard.innerText()})
-
     await appCard.locator('.AppCard__body__subscribed').getByText('Subscribed', { exact: false }).isVisible()
   }
 
@@ -89,7 +87,6 @@ export class InboxPage {
   async countSubscribedDapps() {
 
     const selected = await this.page.locator('AppSelector__list').all()
-    console.log({selected})
     return (await this.page.locator('.AppSelector__notifications').count() - 1)
   }
 
@@ -101,7 +98,6 @@ export class InboxPage {
     await this.page.getByText('Preferences').nth(1).click()
 
     const firstCheckBoxIsChecked = await this.page.isChecked('.Toggle__checkbox:nth-of-type(1)')
-    console.log({firstCheckBoxIsChecked})
     await expect(this.page.locator('.Toggle__label').first()).toBeVisible()
 
     await this.page.locator('.Toggle').first().click()

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -16,7 +16,10 @@ export class InboxPage {
   }
 
   async gotoDiscoverPage() {
-    await this.page.goto(`${this.baseURL}notifications/new-app`)
+    await this.page.locator('.Sidebar__Navigation__Link[href="/notifications"]').click()
+    await this.page.getByText('Discover Apps').click();
+
+    await this.page.getByText('Discover Web3Inbox').isVisible();
   }
 
   async copyConnectUriToClipboard() {
@@ -45,7 +48,7 @@ export class InboxPage {
   }
 
   async getAddress() {
-    await this.page.locator('.Avatar').click()
+    await this.page.locator('.Avatar').first().click()
     await this.page.locator('wui-icon[name=copy]').first().click();
     const copiedAddress: string = this.page.evaluate('navigator.clipboard.readText()') as any
     await this.page.locator('wui-icon[name=close]').first().click();

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -45,14 +45,49 @@ export class InboxPage {
     await this.page.getByText('Subscribed to', { exact: false }).isVisible()
   }
 
-  async unsubscribe(nth: number) {
+  async navigateToNewSubscription(nth: number) {
     await this.page.getByRole('button', { name: 'Subscribed' }).nth(nth).click()
     await this.page.getByRole('button', { name: 'Subscribed' }).nth(nth).isHidden()
+  }
+
+  async subscribeAndNavigateToDapp(nth: number) {
+    await this.subscribe(nth);
+    await this.navigateToNewSubscription(nth);
+  }
+
+  async unsubscribe() {
     await this.page.locator('.AppNotificationsHeader__wrapper > .Dropdown').click()
     await this.page.getByRole('button', { name: 'Unsubscribe' }).click()
     await this.page.getByRole('button', { name: 'Unsubscribe' }).nth(1).click()
     await this.page.getByText('Unsubscribed from', { exact: false }).isVisible()
     await this.page.waitForTimeout(2000)
+  }
+
+  async updatePreferences() {
+    await this.page.locator('.AppNotificationsHeader__wrapper > .Dropdown').click()
+    await this.page.getByRole('button', { name: 'Preferences' }).click()
+    // Ensure the modal is visible
+    await this.page.getByText('Preferences').nth(1).isVisible()
+    await this.page.getByText('Preferences').nth(1).click()
+
+    const firstCheckBoxIsChecked = await this.page.isChecked('.Toggle__checkbox:nth-of-type(1)')
+    console.log({firstCheckBoxIsChecked})
+    await expect(this.page.locator('.Toggle__label').first()).toBeVisible()
+
+    await this.page.locator('.Toggle').first().click()
+
+    await this.page.getByRole('button', { name: 'Update' }).click()
+
+
+    await this.page.locator('.AppNotificationsHeader__wrapper > .Dropdown').click()
+    await this.page.getByRole('button', { name: 'Preferences' }).click()
+
+    const firstCheckBoxIsCheckedAfterUpdating =  await this.page.isChecked('.Toggle__checkbox:nth-of-type(1)')
+
+    expect(firstCheckBoxIsChecked).not.toEqual(firstCheckBoxIsCheckedAfterUpdating)
+
+    await this.page.locator('.PreferencesModal__close').click();
+
   }
 
   async cancelSiwe() {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -90,6 +90,21 @@ export class InboxPage {
     return notificationsCount - 1;
   }
 
+  /**
+   * Waits for a specific number of dApps to be subscribed.
+   * 
+   * @param {number} expectedCount - The expected number of dApps to wait for.
+   * @returns {Promise<void>}
+   */
+  async waitForSubscriptions(expectedCount: number): Promise<void> {
+    // Wait for a function that checks the length of a list or a set of elements
+    // matching a certain condition to equal the expectedCount.
+    await this.page.waitForFunction(([className, count]) => {
+      const elements = document.getElementsByClassName(className)[1].children;;
+      return elements.length === count;
+    }, ['AppSelector__list', expectedCount] as const, { timeout: 5000 }); 
+  }
+
   async updatePreferences() {
     await this.page.locator('.AppNotificationsHeader__wrapper > .Dropdown').click()
     await this.page.getByRole('button', { name: 'Preferences' }).click()

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -85,8 +85,6 @@ export class InboxPage {
   }
 
   async countSubscribedDapps() {
-
-    const selected = await this.page.locator('AppSelector__list').all()
     const notificationsCount = await this.page.locator('.AppSelector__notifications').count()
     
     return notificationsCount - 1;

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -87,7 +87,9 @@ export class InboxPage {
   async countSubscribedDapps() {
 
     const selected = await this.page.locator('AppSelector__list').all()
-    return (await this.page.locator('.AppSelector__notifications').count() - 1)
+    const notificationsCount = await this.page.locator('.AppSelector__notifications').count()
+    
+    return notificationsCount - 1;
   }
 
   async updatePreferences() {

--- a/tests/shared/pages/SettingsPage.ts
+++ b/tests/shared/pages/SettingsPage.ts
@@ -7,12 +7,10 @@ export class SettingsPage {
 
   constructor(public readonly page: Page) {}
 
-  async load() {
-    await this.page.goto(`${this.baseURL}`)
-  }
+  async load() {}
 
   async goToNotificationSettings() {
-    await this.page.goto(`${this.baseURL}settings/notifications`)
+    await this.page.locator('.Sidebar__Navigation__Link[href="/settings"]').click()
   }
 
   async displayCustomDapp(dappUrl: string) {

--- a/tests/shared/pages/SettingsPage.ts
+++ b/tests/shared/pages/SettingsPage.ts
@@ -1,0 +1,23 @@
+import { type Locator, type Page, expect } from '@playwright/test'
+
+import { BASE_URL } from '../../shared/constants'
+
+export class SettingsPage {
+  private readonly baseURL = BASE_URL
+
+  constructor(public readonly page: Page) {}
+
+  async load() {
+    await this.page.goto(`${this.baseURL}`)
+  }
+
+  async goToNotificationSettings() {
+    await this.page.goto(`${this.baseURL}settings/notifications`)
+  }
+
+  async displayCustomDapp(dappUrl: string) {
+    await this.page.getByPlaceholder('app.example.com').fill(dappUrl)
+    await this.page.getByRole('button', { name: "Save", exact: true}).click()
+  }
+
+}

--- a/tests/shared/pages/WalletPage.ts
+++ b/tests/shared/pages/WalletPage.ts
@@ -10,6 +10,8 @@ export class WalletPage {
   private readonly gotoHome: Locator
   private readonly vercelPreview: Locator
 
+  private address: string;
+
   constructor(public readonly page: Page) {
     this.gotoHome = this.page.getByTestId('wc-connect')
     this.vercelPreview = this.page.locator('css=vercel-live-feedback')

--- a/tests/shared/pages/WalletPage.ts
+++ b/tests/shared/pages/WalletPage.ts
@@ -10,8 +10,6 @@ export class WalletPage {
   private readonly gotoHome: Locator
   private readonly vercelPreview: Locator
 
-  private address: string;
-
   constructor(public readonly page: Page) {
     this.gotoHome = this.page.getByTestId('wc-connect')
     this.vercelPreview = this.page.locator('css=vercel-live-feedback')

--- a/tests/shared/validators/ModalValidator.ts
+++ b/tests/shared/validators/ModalValidator.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import type { Page } from '@playwright/test'
 
-export class ModalValidator {
+export class InboxValidator {
   constructor(public readonly page: Page) {}
 
   async expectConnected() {

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -70,6 +70,8 @@ test('it should subscribe and unsubscribe to and from multiple dapps', async ({
   await inboxPage.subscribe(0)
   await inboxPage.subscribe(1)
 
+  await inboxPage.waitForSubscriptions(2)
+
   // Wait for the 2 dapps to be subscribed to.
   await inboxPage.page.waitForFunction(() => {
     // Using 1 here since the first `AppSelector__list` is the one with `Discover Apps`

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -82,7 +82,7 @@ test('it should subscribe and unsubscribe to and from multiple dapps', async ({
 })
 
 
-test('it should subscribe, recieve messages and unsubscribe', async ({
+test('it should subscribe, receive messages and unsubscribe', async ({
   inboxPage,
   walletPage,
   settingsPage,

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -69,6 +69,14 @@ test('it should subscribe and unsubscribe to and from multiple dapps', async ({
   await inboxPage.rejectNotifications()
   await inboxPage.subscribe(0)
   await inboxPage.subscribe(1)
+
+  // Wait for the 2 dapps to be subscribed to.
+  await inboxPage.page.waitForFunction(() => {
+    // Using 1 here since the first `AppSelector__list` is the one with `Discover Apps`
+    const apps = document.getElementsByClassName('AppSelector__list')[1].children.length;
+    return apps === 2;
+  })
+
   expect(await inboxPage.countSubscribedDapps()).toEqual(2);
 
   await inboxPage.navigateToDappFromSidebar(0);

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SESSION_PARAMS } from './shared/constants'
-import { testWallet as test } from './shared/fixtures/wallet-fixture'
+import { expect, testWallet as test } from './shared/fixtures/wallet-fixture'
 
 test.beforeEach(async ({ inboxPage, walletPage, browserName }) => {
   if (browserName === 'webkit') {
@@ -50,5 +50,33 @@ test('it should subscribe, update preferences and unsubscribe', async ({
   await inboxPage.rejectNotifications()
   await inboxPage.subscribeAndNavigateToDapp(0)
   await inboxPage.updatePreferences()
+  await inboxPage.unsubscribe()
+})
+
+test('it should subscribe and unsubscribe to and from multiple dapps', async ({
+  inboxPage,
+  walletPage,
+  walletValidator,
+  browserName
+}) => {
+  if (browserName === 'webkit') {
+    // Clipboard doesn't work here. Remove this when we moved away from Clipboard in favor of links
+    test.skip()
+  }
+  await inboxPage.promptSiwe()
+  await walletValidator.expectReceivedSign({})
+  await walletPage.handleRequest({ accept: true })
+  await inboxPage.rejectNotifications()
+  await inboxPage.subscribe(0)
+  await inboxPage.subscribe(1)
+  expect(await inboxPage.countSubscribedDapps()).toEqual(2);
+
+  await inboxPage.navigateToDappFromSidebar(0);
+  await inboxPage.unsubscribe()
+  expect(await inboxPage.countSubscribedDapps()).toEqual(1);
+
+  // select 0 again since we unsubscribed from the second dapp
+  // so there is only one item
+  await inboxPage.navigateToDappFromSidebar(0);
   await inboxPage.unsubscribe()
 })

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -1,23 +1,23 @@
 import { DEFAULT_SESSION_PARAMS } from './shared/constants'
 import { testWallet as test } from './shared/fixtures/wallet-fixture'
 
-test.beforeEach(async ({ modalPage, walletPage, browserName }) => {
+test.beforeEach(async ({ inboxPage, walletPage, browserName }) => {
   if (browserName === 'webkit') {
     // Clipboard doesn't work here. Remove this when we moved away from Clipboard in favor of links
     test.skip()
   }
-  await modalPage.copyConnectUriToClipboard()
+  await inboxPage.copyConnectUriToClipboard()
   await walletPage.connect()
   await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
 })
 
-test.afterEach(async ({ modalValidator, walletValidator }) => {
-  await modalValidator.expectDisconnected()
+test.afterEach(async ({ inboxValidator, walletValidator }) => {
+  await inboxValidator.expectDisconnected()
   await walletValidator.expectDisconnected()
 })
 
 test('it should subscribe and unsubscribe', async ({
-  modalPage,
+  inboxPage,
   walletPage,
   walletValidator,
   browserName
@@ -26,10 +26,29 @@ test('it should subscribe and unsubscribe', async ({
     // Clipboard doesn't work here. Remove this when we moved away from Clipboard in favor of links
     test.skip()
   }
-  await modalPage.promptSiwe()
+  await inboxPage.promptSiwe()
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
-  await modalPage.rejectNotifications()
-  await modalPage.subscribe(0)
-  await modalPage.unsubscribe(0)
+  await inboxPage.rejectNotifications()
+  await inboxPage.subscribeAndNavigateToDapp(0)
+  await inboxPage.unsubscribe()
+})
+
+test('it should subscribe, update preferences and unsubscribe', async ({
+  inboxPage,
+  walletPage,
+  walletValidator,
+  browserName
+}) => {
+  if (browserName === 'webkit') {
+    // Clipboard doesn't work here. Remove this when we moved away from Clipboard in favor of links
+    test.skip()
+  }
+  await inboxPage.promptSiwe()
+  await walletValidator.expectReceivedSign({})
+  await walletPage.handleRequest({ accept: true })
+  await inboxPage.rejectNotifications()
+  await inboxPage.subscribeAndNavigateToDapp(0)
+  await inboxPage.updatePreferences()
+  await inboxPage.unsubscribe()
 })

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -106,7 +106,6 @@ test('it should subscribe, receive messages and unsubscribe', async ({
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
   await inboxPage.rejectNotifications()
-  await inboxPage.subscribe(0)
 
   await settingsPage.goToNotificationSettings()
   await settingsPage.displayCustomDapp(CUSTOM_TEST_DAPP.appDomain)

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -98,6 +98,7 @@ test('it should subscribe, recieve messages and unsubscribe', async ({
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
   await inboxPage.rejectNotifications()
+  await inboxPage.subscribe(0)
 
   await settingsPage.goToNotificationSettings()
   await settingsPage.displayCustomDapp(CUSTOM_TEST_DAPP.appDomain)
@@ -105,9 +106,11 @@ test('it should subscribe, recieve messages and unsubscribe', async ({
   await inboxPage.gotoDiscoverPage()
 
   // Ensure the custom dapp is the one subscribed to
-  expect(await inboxPage.page.getByText(CUSTOM_TEST_DAPP.appDomain).isVisible()).toEqual(true)
+  await inboxPage.page.getByText("Notify Swift", {exact: false}).waitFor({ state: 'visible' })
 
-  await inboxPage.subscribe(0)
+  expect(await inboxPage.page.getByText("Notify Swift", {exact: false}).isVisible()).toEqual(true);
+  
+  await inboxPage.subscribeAndNavigateToDapp(0)
 
   if(!CUSTOM_TEST_DAPP.projectId || !(CUSTOM_TEST_DAPP.projectSecret)) {
     throw new Error("TEST_DAPP_SECRET and TEST_DAPP_ID are required")
@@ -116,7 +119,7 @@ test('it should subscribe, recieve messages and unsubscribe', async ({
   const address = await inboxPage.getAddress()
 
   await notifyServer.sendMessage({
-    accounts: [address],
+    accounts: [`eip155:1:${address}`],
     body: "Test Body",
     title: "Test Title",
     type: CUSTOM_TEST_DAPP.messageType,
@@ -126,6 +129,7 @@ test('it should subscribe, recieve messages and unsubscribe', async ({
     projectSecret: CUSTOM_TEST_DAPP.projectSecret,
   })
 
-  expect(await inboxPage.page.getByText("Test Body").isVisible()).toEqual(true)
+  await inboxPage.page.getByText("Test Body").waitFor({state: 'visible'})
 
+  expect(await inboxPage.page.getByText("Test Body").isVisible()).toEqual(true)
 })


### PR DESCRIPTION
# Description

- Round 1 Of Adding E2E tests
- With this, the following is tested
  - Subscribe :heavy_check_mark: 
  - Unsubscribe :heavy_check_mark: 
  - Update preferences :heavy_check_mark: 
  - Subscribe and Unsubscribe from multiple dapps and ensure state works :heavy_check_mark: 
  - Receive messages :heavy_check_mark: 
- Disable webkit tests since all actually useful tests were disabled on Webklit and it was causing nothing but headaches

# Type of change

- [x] Tests
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Note
The following is yet to be tested and could be very beneficial to test:
- Paging of notification history :x: 
- Further testing of preferences :x:
- UI tests / responsiveness :x:
- Read more in messages :x:
