### PR TITLE
fix: avoid subscribing to non-test apps, subscribe by name not index

### DIFF
--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -55,24 +55,34 @@ export class InboxPage {
     return address
   }
 
-  async subscribe(nth: number) {
-    const appCard = this.page.locator('.AppCard__body').nth(nth)
-    await appCard.locator('.AppCard__body__subscribe').click()
+  async subscribe(appName: string) {
+    const appCard = this.page.locator('.AppCard', {
+      has: this.page.locator('.AppCard__body__title', {
+        hasText: appName
+      })
+    })
+    await appCard.locator('.AppCard__body > .AppCard__body__subscribe').click()
 
     await appCard
-      .locator('.AppCard__body__subscribed')
+      .locator('.AppCard__body > .AppCard__body__subscribed')
       .getByText('Subscribed', { exact: false })
       .isVisible()
   }
 
-  async navigateToNewSubscription(nth: number) {
-    await this.page.getByRole('button', { name: 'Subscribed' }).nth(nth).click()
-    await this.page.getByRole('button', { name: 'Subscribed' }).nth(nth).isHidden()
+  async navigateToNewSubscription(appName: string) {
+    const appCard = this.page.locator('.AppCard', {
+      has: this.page.locator('.AppCard__body__title', {
+        hasText: appName
+      })
+    })
+    const subscribeButton = appCard.getByRole('button', { name: 'Subscribed' })
+    await subscribeButton.click()
+    await subscribeButton.isHidden()
   }
 
-  async subscribeAndNavigateToDapp(nth: number) {
-    await this.subscribe(nth)
-    await this.navigateToNewSubscription(nth)
+  async subscribeAndNavigateToDapp(appName: string) {
+    await this.subscribe(appName)
+    await this.navigateToNewSubscription(appName)
   }
 
   async unsubscribe() {
@@ -83,8 +93,12 @@ export class InboxPage {
     await this.page.waitForTimeout(2000)
   }
 
-  async navigateToDappFromSidebar(nth: number) {
-    await this.page.locator('.AppSelector__notifications-link').nth(nth).click()
+  async navigateToDappFromSidebar(appName: string) {
+    await this.page
+      .locator('.AppSelector__notifications-link', {
+        has: this.page.locator('.AppSelector__link__title', { hasText: appName })
+      })
+      .click()
   }
 
   async countSubscribedDapps() {

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -19,6 +19,7 @@ test.afterEach(async ({ inboxValidator, walletValidator }) => {
 test('it should subscribe and unsubscribe', async ({
   inboxPage,
   walletPage,
+  settingsPage,
   walletValidator,
   browserName
 }) => {
@@ -30,13 +31,19 @@ test('it should subscribe and unsubscribe', async ({
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
   await inboxPage.rejectNotifications()
-  await inboxPage.subscribeAndNavigateToDapp(0)
+
+  await settingsPage.goToNotificationSettings()
+  await settingsPage.displayCustomDapp(CUSTOM_TEST_DAPP.appDomain)
+  await inboxPage.gotoDiscoverPage()
+
+  await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
   await inboxPage.unsubscribe()
 })
 
 test('it should subscribe, update preferences and unsubscribe', async ({
   inboxPage,
   walletPage,
+  settingsPage,
   walletValidator,
   browserName
 }) => {
@@ -48,7 +55,12 @@ test('it should subscribe, update preferences and unsubscribe', async ({
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
   await inboxPage.rejectNotifications()
-  await inboxPage.subscribeAndNavigateToDapp(0)
+
+  await settingsPage.goToNotificationSettings()
+  await settingsPage.displayCustomDapp(CUSTOM_TEST_DAPP.appDomain)
+  await inboxPage.gotoDiscoverPage()
+
+  await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
   await inboxPage.updatePreferences()
   await inboxPage.unsubscribe()
 })
@@ -56,6 +68,7 @@ test('it should subscribe, update preferences and unsubscribe', async ({
 test('it should subscribe and unsubscribe to and from multiple dapps', async ({
   inboxPage,
   walletPage,
+  settingsPage,
   walletValidator,
   browserName
 }) => {
@@ -67,8 +80,13 @@ test('it should subscribe and unsubscribe to and from multiple dapps', async ({
   await walletValidator.expectReceivedSign({})
   await walletPage.handleRequest({ accept: true })
   await inboxPage.rejectNotifications()
-  await inboxPage.subscribe(0)
-  await inboxPage.subscribe(1)
+
+  await settingsPage.goToNotificationSettings()
+  await settingsPage.displayCustomDapp(CUSTOM_TEST_DAPP.appDomain)
+  await inboxPage.gotoDiscoverPage()
+
+  await inboxPage.subscribe(CUSTOM_TEST_DAPP.name)
+  await inboxPage.subscribe('GM Dapp')
 
   await inboxPage.waitForSubscriptions(2)
 
@@ -81,13 +99,13 @@ test('it should subscribe and unsubscribe to and from multiple dapps', async ({
 
   expect(await inboxPage.countSubscribedDapps()).toEqual(2)
 
-  await inboxPage.navigateToDappFromSidebar(0)
+  await inboxPage.navigateToDappFromSidebar(CUSTOM_TEST_DAPP.name)
   await inboxPage.unsubscribe()
   expect(await inboxPage.countSubscribedDapps()).toEqual(1)
 
   // select 0 again since we unsubscribed from the second dapp
   // so there is only one item
-  await inboxPage.navigateToDappFromSidebar(0)
+  await inboxPage.navigateToDappFromSidebar('GM Dapp')
   await inboxPage.unsubscribe()
 })
 
@@ -117,12 +135,8 @@ test('it should subscribe, receive messages and unsubscribe', async ({
   await inboxPage.page.getByText('Notify Swift', { exact: false }).waitFor({ state: 'visible' })
 
   expect(await inboxPage.page.getByText('Notify Swift', { exact: false }).isVisible()).toEqual(true)
-
-  await inboxPage.subscribeAndNavigateToDapp(0)
-
-  if (!CUSTOM_TEST_DAPP.projectId || !CUSTOM_TEST_DAPP.projectSecret) {
-    throw new Error('TEST_DAPP_SECRET and TEST_DAPP_ID are required')
-  }
+  
+  await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
 
   const address = await inboxPage.getAddress()
 


### PR DESCRIPTION
Avoid subscribing to random apps by their position on the discover page. Instead, we should only subscribe to internal ones (i.e. Notify Swift Integration Tests Prod). For now subscribing to GM Dapp for the "2 subscriptions" test case, but we must find a way to avoid polluting GM Dapp metrics with ephemeral wallet addresses.