### PR TITLE
refactor: update discover page route

### DIFF
--- a/src/components/layout/MobileFooter/index.tsx
+++ b/src/components/layout/MobileFooter/index.tsx
@@ -6,6 +6,7 @@ import NewAppIcon from '@/components/general/Icon/NewAppIcon'
 import NotificationIcon from '@/components/general/Icon/NotificationIcon'
 import SettingIcon from '@/components/general/Icon/SettingIcon'
 import W3iContext from '@/contexts/W3iContext/context'
+import { NAVIGATION } from '@/utils/constants'
 
 import './MobileFooter.scss'
 
@@ -23,11 +24,17 @@ const MobileFooter: React.FC = () => {
     }
 
     if (uiEnabled.notify) {
-      items.push([<NewAppIcon isFilled={pathname.includes('/new-app')} />, 'notifications/new-app'])
+      items.push([
+        <NotificationIcon isFilled={pathname.startsWith(NAVIGATION.notifications.index)} />,
+        NAVIGATION.notifications.index
+      ])
     }
 
     if (uiEnabled.settings) {
-      items.push([<SettingIcon isFilled={pathname.includes('/settings')} />, 'settings'])
+      items.push([
+        <SettingIcon isFilled={pathname.startsWith(NAVIGATION.settings.index)} />,
+        NAVIGATION.settings.index
+      ])
     }
 
     return items

--- a/src/components/layout/MobileHeader/index.tsx
+++ b/src/components/layout/MobileHeader/index.tsx
@@ -9,6 +9,7 @@ import Text from '@/components/general/Text'
 import AppNotificationDropdown from '@/components/notifications/AppNotifications/AppNotificationDropdown'
 import W3iContext from '@/contexts/W3iContext/context'
 import { getEthChainAddress } from '@/utils/address'
+import { NAVIGATION } from '@/utils/constants'
 
 import './MobileHeader.scss'
 
@@ -35,7 +36,7 @@ const MobileHeader: React.FC<IMobileHeaderProps> = ({ title, back, notificationI
           <ArrowLeftIcon />
         </div>
       ) : (
-        <Link className="MobileHeader__icon" to={`/notifications/new-app`}>
+        <Link className="MobileHeader__icon" to={NAVIGATION.notifications.index}>
           <img alt="Web3Inbox icon" className="wc-icon" src="/icon.png" />
         </Link>
       )}

--- a/src/components/layout/Sidebar/index.tsx
+++ b/src/components/layout/Sidebar/index.tsx
@@ -69,7 +69,7 @@ const Sidebar: React.FC<{ isLoggedIn: boolean }> = ({ isLoggedIn }) => {
     <div className="Sidebar">
       {!isMobile && (
         <SidebarItem>
-          <Link to={`/notifications/new-app`}>
+          <Link to={NAVIGATION.notifications.index}>
             <img alt="Web3Inbox icon" className="wc-icon" src="/icon.png" />
           </Link>
         </SidebarItem>

--- a/src/components/notifications/AppExplorer/Previous.tsx
+++ b/src/components/notifications/AppExplorer/Previous.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+import { useNavigate } from 'react-router-dom'
+
+/**
+ * We are changing the home page from /notifications/new-app to /notifications/discover.
+ * Since we have thousands of users, we might need to redirect them to the new home page in case they have the old one bookmarked.
+ */
+export default function AppExplorerPrevious() {
+  const nav = useNavigate()
+
+  useEffect(() => {
+    nav('/notifications/discover', {
+      replace: true
+    })
+  }, [])
+
+  return null
+}

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -104,14 +104,14 @@ const AppSelector: React.FC = () => {
           icon={SearchIcon}
         />
       )}
-      <TargetTitle className="AppSelector__target-title" to="/notifications/new-app">
+      <TargetTitle className="AppSelector__target-title" to={NAVIGATION.notifications.index}>
         <Text variant="large-700">Inbox</Text>
       </TargetTitle>
       <div className="AppSelector__lists">
         <div className="AppSelector__wrapper">
           <Label color="main">Discover</Label>
           <ul className="AppSelector__list">
-            <NavLink to={`/notifications/new-app`} end className="AppSelector__link-appsItem">
+            <NavLink to={NAVIGATION.notifications.index} end className="AppSelector__link-appsItem">
               <div className="AppSelector__notifications">
                 <div className="AppSelector__notifications-apps">
                   <img

--- a/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
+++ b/src/components/notifications/NotificationsLayout/UnsubscribeModal/index.tsx
@@ -8,6 +8,7 @@ import { Modal } from '@/components/general/Modal/Modal'
 import Spinner from '@/components/general/Spinner'
 import Text from '@/components/general/Text'
 import W3iContext from '@/contexts/W3iContext/context'
+import { NAVIGATION } from '@/utils/constants'
 import { logError } from '@/utils/error'
 import { useModals } from '@/utils/hooks'
 import { unsubscribeModalService } from '@/utils/store'
@@ -35,7 +36,7 @@ export const UnsubscribeModal: React.FC = () => {
             unsubscribeModalService.closeModal()
             showDefaultToast(`Unsubscribed from ${app ? app.metadata.name : `dapp`}`)
             setLoading(false)
-            navigate('/notifications/new-app')
+            navigate(NAVIGATION.notifications.index)
           }
         })
         await notifyClientProxy.deleteSubscription({ topic: unsubscribeModalAppId })
@@ -69,8 +70,8 @@ export const UnsubscribeModal: React.FC = () => {
           </div>
           <div className="UnsubscribeModal__content__helper-text">
             <Text variant="small-500">
-              You will stop receiving all notifications from {app.metadata.name} on Web3Inbox
-              and connected wallets.
+              You will stop receiving all notifications from {app.metadata.name} on Web3Inbox and
+              connected wallets.
               <br />
               You can re-subscribe at any time later.
             </Text>

--- a/src/components/notifications/NotificationsLayout/index.tsx
+++ b/src/components/notifications/NotificationsLayout/index.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 
 import W3iContext from '@/contexts/W3iContext/context'
+import { NAVIGATION } from '@/utils/constants'
 
 import AppSelector from '../AppSelector'
 
@@ -16,9 +17,9 @@ const NotificationsLayout: React.FC = () => {
   const nav = useNavigate()
 
   useEffect(() => {
-    if (pathname === '/notifications') {
+    if (pathname === '/notifications/' || pathname === '/notifications') {
       if (!activeSubscriptions.length) {
-        nav('/notifications/new-app')
+        nav(NAVIGATION.notifications.index, { replace: true })
       }
     }
   }, [])

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-nested-ternary */
 import { useContext } from 'react'
 
-import { Navigate, Route, Routes } from 'react-router-dom'
+import { Navigate, Route, Routes, redirect } from 'react-router-dom'
 
 import App from '@/App'
 import AppExplorer from '@/components/notifications/AppExplorer'
+import AppExplorerPrevious from '@/components/notifications/AppExplorer/Previous'
 import AppNotifications from '@/components/notifications/AppNotifications'
 import NotificationsLayout from '@/components/notifications/NotificationsLayout'
 import AppearanceSettings from '@/components/settings/AppearanceSettings'
@@ -30,13 +31,18 @@ const ConfiguredRoutes: React.FC = () => {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
-
       <Route path="/qrcode-scan" element={<ScanQrCode />} />
-
       <Route path="/" element={<App />}>
         {uiEnabled.notify ? (
           <Route path="/notifications" element={<NotificationsLayout />}>
-            <Route path="/notifications/new-app" element={<AppExplorer />} />
+            <Route
+              path="/notifications/new-app"
+              action={() => {
+                return redirect('/notifications/discover')
+              }}
+              element={<AppExplorerPrevious />}
+            />
+            <Route path="/notifications/discover" element={<AppExplorer />} />
             <Route path="/notifications/:topic" element={<AppNotifications />} />
           </Route>
         ) : null}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -16,7 +16,7 @@ export const NAVIGATION = {
     index: '/messages'
   },
   notifications: {
-    index: '/notifications',
+    index: '/notifications/discover',
     topic: (topic: string) => `/notifications/${topic}`
   },
   settings: {


### PR DESCRIPTION
# Description

- Change the discover page route from `/new-app` to `/discover` and handle all previous route hrefs.
- Use `NAVIGATION` constant to use hrefs

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Additional Information (Optional)

[Slack thread](https://walletconnect.slack.com/archives/C044SKFKELR/p1709750126958689)