### PR TITLE
chore: add clever clamping

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,6 @@ const baseURL = 'http://localhost:5173'
  */
 export default defineConfig({
   testDir: './tests',
-  timeout: 1.5 * 60 * 1000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
-import { config } from 'dotenv'
 import { defineConfig, devices } from '@playwright/test'
+import { config } from 'dotenv'
+
 config({ path: './.env' })
 
 const baseURL = 'http://localhost:5173'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ const baseURL = 'http://localhost:5173'
  */
 export default defineConfig({
   testDir: './tests',
+  timeout: 1.5 * 60 * 1000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/src/components/notifications/AppNotifications/AppNotificationItem.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationItem.tsx
@@ -55,10 +55,13 @@ const AppNotificationItem = forwardRef<HTMLDivElement, IAppNotificationProps>(
     useEffect(() => {
       if (!notificationBodyRef.current) return
 
+      // Need to use resize observer in the case of browsers resizing the window.
       const resizeObserver = new ResizeObserver(() => {
+	// If it's expanded then we don't need to check for clamping.
         if (!showMore) {
           setIsClamped(
             notificationBodyRef.current
+	      // Depend on dom as single source of truth for clamping.
               ? notificationBodyRef.current.scrollHeight > notificationBodyRef.current.clientHeight
               : false
           )

--- a/src/components/notifications/AppNotifications/AppNotificationItem.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationItem.tsx
@@ -42,40 +42,40 @@ const AppNotificationItemLink: React.FC<{
 
 const AppNotificationItem = forwardRef<HTMLDivElement, IAppNotificationProps>(
   ({ notification, appLogo }, ref) => {
-
     const formattedTime = useFormattedTime(notification.timestamp)
 
-    const [showMore, setShowMore] = useState(false);
+    const [showMore, setShowMore] = useState(false)
 
-    const notificationBodyRef = useRef<HTMLDivElement>(null);
+    const notificationBodyRef = useRef<HTMLDivElement>(null)
 
-    const body = notification.message;
+    const body = notification.message
 
     const [isClamped, setIsClamped] = useState(false)
 
-
     useEffect(() => {
-      if(!notificationBodyRef.current) return;
+      if (!notificationBodyRef.current) return
 
       const resizeObserver = new ResizeObserver(() => {
-	if(!showMore) {
-	setIsClamped(notificationBodyRef.current ?
-      notificationBodyRef.current.scrollHeight > notificationBodyRef.current.clientHeight
-	  : false)
-	}
+        if (!showMore) {
+          setIsClamped(
+            notificationBodyRef.current
+              ? notificationBodyRef.current.scrollHeight > notificationBodyRef.current.clientHeight
+              : false
+          )
+        }
       })
 
-      resizeObserver.observe(notificationBodyRef.current);
+      resizeObserver.observe(notificationBodyRef.current)
 
       return () => {
-	if(!notificationBodyRef.current) return;
-	resizeObserver.unobserve(notificationBodyRef.current)
+        if (!notificationBodyRef.current) return
+        resizeObserver.unobserve(notificationBodyRef.current)
       }
     })
 
     const handleToggleReadMore = (e: React.MouseEvent) => {
-      e.preventDefault();
-      setShowMore((currentShowMore) => !currentShowMore)
+      e.preventDefault()
+      setShowMore(currentShowMore => !currentShowMore)
     }
 
     return (
@@ -124,7 +124,7 @@ const AppNotificationItem = forwardRef<HTMLDivElement, IAppNotificationProps>(
             </div>
             <Text
               className={cn('AppNotifications__item__message', showMore && 'show_more')}
-	      ref={notificationBodyRef}
+              ref={notificationBodyRef}
               variant="small-400"
             >
               {body}
@@ -136,7 +136,8 @@ const AppNotificationItem = forwardRef<HTMLDivElement, IAppNotificationProps>(
               >
                 <Text variant="small-400">{showMore ? 'Show less' : 'Show more'}</Text>
               </button>
-            )}          </div>
+            )}{' '}
+          </div>
         </AppNotificationItemLink>
       </LazyMotion>
     )

--- a/src/components/notifications/AppNotifications/AppNotificationItem.tsx
+++ b/src/components/notifications/AppNotifications/AppNotificationItem.tsx
@@ -3,7 +3,6 @@ import { forwardRef, useEffect, useRef, useState } from 'react'
 import cn from 'classnames'
 import { LazyMotion, domMax } from 'framer-motion'
 import { Link } from 'react-router-dom'
-import debounce from "lodash.debounce"
 
 import ArrowRightTopIcon from '@/components/general/Icon/ArrowRightTopIcon'
 import CircleIcon from '@/components/general/Icon/CircleIcon'

--- a/src/components/notifications/AppNotifications/AppNotifications.scss
+++ b/src/components/notifications/AppNotifications/AppNotifications.scss
@@ -230,9 +230,9 @@
     &__message {
       color: var(--fg-color-1);
       display: -webkit-box;
-      -webkit-line-clamp: 3;
       -webkit-box-orient: vertical;
       overflow: hidden;
+      line-height: 18px;
       margin-top: 0.25rem;
       letter-spacing: -0.14px;
 

--- a/src/components/notifications/AppNotifications/AppNotifications.scss
+++ b/src/components/notifications/AppNotifications/AppNotifications.scss
@@ -247,7 +247,6 @@
       }
 
       &.show_more {
-        color: red;
         max-height: unset;
         -webkit-line-clamp: unset;
       }

--- a/src/components/notifications/AppNotifications/AppNotifications.scss
+++ b/src/components/notifications/AppNotifications/AppNotifications.scss
@@ -227,10 +227,12 @@
         }
       }
     }
+
     &__message {
       color: var(--fg-color-1);
       display: -webkit-box;
       -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
       overflow: hidden;
       line-height: 18px;
       margin-top: 0.25rem;
@@ -243,11 +245,14 @@
       + .Anchor {
         margin-top: 0.75rem;
       }
+
+      &.show_more {
+        color: red;
+        max-height: unset;
+        -webkit-line-clamp: unset;
+      }
     }
-    &__message.show_more {
-      max-height: unset;
-      -webkit-line-clamp: unset;
-    }
+
     &__show_button {
       color: var(--accent-color-1);
       background: none;

--- a/src/components/notifications/AppSelector/index.tsx
+++ b/src/components/notifications/AppSelector/index.tsx
@@ -68,56 +68,63 @@ const AppSelector: React.FC = () => {
           </ul>
         </div>
         <div className="AppSelector__wrapper">
-          {!activeSubscriptions?.length || !subscriptionsFinishedLoading ? <Label color="main">Subscribed</Label> : null}
+          {!activeSubscriptions?.length || !subscriptionsFinishedLoading ? (
+            <Label color="main">Subscribed</Label>
+          ) : null}
           <ul className="AppSelector__list">
             {subscriptionsFinishedLoading &&
-              activeSubscriptions?.filter((sub) => {
-		if(search) {
-		  return sub.metadata.name.toLowerCase().includes(search.toLowerCase())
-		}
-		return true;
-
-	      }).map((app, idx, fullApps) => {
-                return (
-                  <AnimatePresence key={app.topic}>
-                    <m.div initial={{ opacity: 0 }} exit={{ opacity: 0 }} animate={{ opacity: 1 }}>
-                      <NavLink
-                        key={app.topic}
-                        to={NAVIGATION.notifications.domain(app.metadata.appDomain)}
-                        className={cx(
-                          'AppSelector__link-item',
-                          !subscriptionsFinishedLoading &&
-                            fullApps.length - idx + 1 === 0 &&
-                            'AppSelector__link-item-loading-in'
-                        )}
+              activeSubscriptions
+                ?.filter(sub => {
+                  if (search) {
+                    return sub.metadata.name.toLowerCase().includes(search.toLowerCase())
+                  }
+                  return true
+                })
+                .map((app, idx, fullApps) => {
+                  return (
+                    <AnimatePresence key={app.topic}>
+                      <m.div
+                        initial={{ opacity: 0 }}
+                        exit={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
                       >
-                        <div className="AppSelector__notifications">
-                          <div className="AppSelector__notifications-link">
-                            <div className="AppSelector__link__logo">
-                              <img
-                                className="AppSelector__link__logo__image"
-                                src={app.metadata.icons?.[0] || '/fallback.svg'}
-                                alt={`${app.metadata.name} logo`}
-                                onError={handleImageFallback}
-                                loading="lazy"
-                              />
-                            </div>
+                        <NavLink
+                          key={app.topic}
+                          to={NAVIGATION.notifications.domain(app.metadata.appDomain)}
+                          className={cx(
+                            'AppSelector__link-item',
+                            !subscriptionsFinishedLoading &&
+                              fullApps.length - idx + 1 === 0 &&
+                              'AppSelector__link-item-loading-in'
+                          )}
+                        >
+                          <div className="AppSelector__notifications">
+                            <div className="AppSelector__notifications-link">
+                              <div className="AppSelector__link__logo">
+                                <img
+                                  className="AppSelector__link__logo__image"
+                                  src={app.metadata.icons?.[0] || '/fallback.svg'}
+                                  alt={`${app.metadata.name} logo`}
+                                  onError={handleImageFallback}
+                                  loading="lazy"
+                                />
+                              </div>
 
-                            <div className="AppSelector__link__wrapper">
-                              <Text className="AppSelector__link__title" variant="small-500">
-                                {app.metadata.name}
-                              </Text>
-                              <Text className="AppSelector__link__subtitle" variant="small-500">
-                                {app.metadata.description}
-                              </Text>
+                              <div className="AppSelector__link__wrapper">
+                                <Text className="AppSelector__link__title" variant="small-500">
+                                  {app.metadata.name}
+                                </Text>
+                                <Text className="AppSelector__link__subtitle" variant="small-500">
+                                  {app.metadata.description}
+                                </Text>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      </NavLink>
-                    </m.div>
-                  </AnimatePresence>
-                )
-              })}
+                        </NavLink>
+                      </m.div>
+                    </AnimatePresence>
+                  )
+                })}
             {!subscriptionsFinishedLoading ? SkeletonItems : null}
           </ul>
         </div>

--- a/tests/canary.spec.ts
+++ b/tests/canary.spec.ts
@@ -49,7 +49,7 @@ test('it should subscribe, receive messages and unsubscribe', async ({
   await inboxPage.page.getByText('Notify Swift', { exact: false }).waitFor({ state: 'visible' })
 
   expect(await inboxPage.page.getByText('Notify Swift', { exact: false }).isVisible()).toEqual(true)
-  
+
   await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
 
   const address = await inboxPage.getAddress()

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -135,7 +135,7 @@ test('it should subscribe, receive messages and unsubscribe', async ({
   await inboxPage.page.getByText('Notify Swift', { exact: false }).waitFor({ state: 'visible' })
 
   expect(await inboxPage.page.getByText('Notify Swift', { exact: false }).isVisible()).toEqual(true)
-  
+
   await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
 
   const address = await inboxPage.getAddress()


### PR DESCRIPTION
# Description
- Use clever clamping logic :tm: to only clamp text after it has gone over the line limit, and if it has always have a show more button
- Lower clamp length 

> [!NOTE]
> You can test this by for example sending yourself a message with length 142. It won't have a show more button on mobile, but it will here

# Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Fixes/Resolves (Optional)

- Resolves #513 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
