### PR TITLE
chore: add logic to retry modal

### DIFF
--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -31,9 +31,13 @@ export class InboxPage {
     let retryModal = 0;
     let qrCodeVisible = false;
 
-    const qrCode = this.page.locator('wui-qr-code')
+      const qrCode = this.page.locator('wui-qr-code')
 
     while(retryModal < 3 && !qrCodeVisible) {
+      await this.connectButton.waitFor({
+	state: 'visible'
+      })
+
       await this.connectButton.click()
       const connect = this.page.getByTestId('wallet-selector-walletconnect')
       await connect.waitFor({
@@ -43,7 +47,7 @@ export class InboxPage {
       await connect.click()
 
       retryModal++;
-      qrCode.waitFor({
+      await qrCode.waitFor({
         state: 'visible',
         timeout: 10_000
       })


### PR DESCRIPTION
# Description

- Retry modal if loading qr code fails

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules