### PR TITLE
fix: run canary once

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier:write": "prettier --write '**/*.{js,ts,jsx,tsx,scss}'",
     "playwright:install": "playwright install --with-deps",
     "playwright:test": "playwright test",
-    "playwright:test:canary": "playwright test --retries=0 --grep canary.spec.ts",
+    "playwright:test:canary": "playwright test --retries=0 --grep canary.spec.ts --project=chromium",
     "playwright:debug": "playwright test --debug"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes that the canary was being run for multiple projects

Same as Web3Modal canary: https://github.com/WalletConnect/web3modal/blob/41e1ab9c33e5506b86de950d16797aa6b3e64b6f/apps/laboratory/package.json#L17