### PR TITLE
fix: failing cases hang

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -14,5 +14,9 @@ RUN yarn build
 
 RUN yarn playwright:install
 
+# Seems that sometimes Playwright will get stuck on serving the HTML report server
+# Setting CI=true will prevent that
+ENV CI=true
+
 ENV PRE_BUILD=true
 CMD ["yarn", "playwright:test:canary"]


### PR DESCRIPTION
Seems like when a test fails it hangs the ECS task and doesn't exist. Setting `CI=true` will prevent this. [Slack conversation](https://walletconnect.slack.com/archives/C058RS0MH38/p1715173506598119)