### PR TITLE
chore: canary trace uploads

### DIFF
--- a/Dockerfile.canary
+++ b/Dockerfile.canary
@@ -1,4 +1,5 @@
 FROM node:20-bookworm
+RUN apt update && apt install -y awscli
 
 WORKDIR /src
 
@@ -19,4 +20,4 @@ RUN yarn playwright:install
 ENV CI=true
 
 ENV PRE_BUILD=true
-CMD ["yarn", "playwright:test:canary"]
+CMD ["bash", "./docker-canary.sh"]

--- a/docker-canary.sh
+++ b/docker-canary.sh
@@ -1,0 +1,7 @@
+# Not adding `set -e` so that S3 upload happens regardless
+
+yarn playwright:test:canary
+
+destination="s3://$TEST_RESULTS_BUCKET/web3inbox-canary/$(date --iso-8601=seconds)/test-results/"
+echo "Uploading test results to $destination"
+aws s3 cp ./test-results/ $destination --recursive

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL,
+    /* Collect trace regardless so we can debug latency regressions. See https://playwright.dev/docs/trace-viewer */
     trace: 'on',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure'


### PR DESCRIPTION
Uploads Playwright traces to S3 (like in Web3Modal canary) to enable debugging of failures and latency regressions.