### PR TITLE
chore: reverse order for new notification

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,9 @@ import { config } from 'dotenv'
 
 config({ path: './.env' })
 
-const baseURL = process.env['BASE_URL'] || (process.env.PRE_BUILD ? 'http://localhost:4173/' : 'http://localhost:5173')
+const baseURL =
+  process.env['BASE_URL'] ||
+  (process.env.PRE_BUILD ? 'http://localhost:4173/' : 'http://localhost:5173')
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -39,7 +41,7 @@ export default defineConfig({
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] }
-    },
+    }
     // {
     //   name: 'safari',
     //   use: { ...devices['Desktop Safari'] }

--- a/src/Modals.tsx
+++ b/src/Modals.tsx
@@ -38,7 +38,7 @@ export const Modals = () => {
   const explicitlyDeniedOnDesktop = !isMobile() && window.Notification?.permission === 'denied'
   const shouldShowChangeBrowserModal = isAppleMobile ? isNonSafari : false
   const shouldShowPWAModal = isMobileButNotInstalledOnHomeScreen && !shouldShowChangeBrowserModal
-  const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal;
+  const shouldShowSignatureModal = isSignatureModalOpen && !shouldShowChangeBrowserModal
   const shouldShowUnsubscribeModalOpen = isUnsubscribeModalOpen && !shouldShowChangeBrowserModal
   const shouldShowPreferencesModalOpen = isPreferencesModalOpen && !shouldShowChangeBrowserModal
 
@@ -53,20 +53,26 @@ export const Modals = () => {
     !shouldShowChangeBrowserModal
 
   useEffect(() => {
-    const shouldOpenSignatureModal = !notifyRegisteredKey &&
-    (isSignatureModalOpen || (userPubkey && clientReady && !notifyRegisteredKey)) &&
-    !shouldShowChangeBrowserModal
+    const shouldOpenSignatureModal =
+      !notifyRegisteredKey &&
+      (isSignatureModalOpen || (userPubkey && clientReady && !notifyRegisteredKey)) &&
+      !shouldShowChangeBrowserModal
 
-    if(shouldOpenSignatureModal) {
-      if(!isSigning) {
+    if (shouldOpenSignatureModal) {
+      if (!isSigning) {
         signatureModalService.openModal()
       }
-    }
-    else {
+    } else {
       signatureModalService.closeModal()
     }
-
-  }, [isSigning, isSignatureModalOpen, notifyRegisteredKey, userPubkey, clientReady, shouldShowChangeBrowserModal])
+  }, [
+    isSigning,
+    isSignatureModalOpen,
+    notifyRegisteredKey,
+    userPubkey,
+    clientReady,
+    shouldShowChangeBrowserModal
+  ])
 
   useEffect(() => {
     // Create an artificial delay to prevent modals being spammed one after the other

--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -39,7 +39,7 @@ const AppNotifications = () => {
 
   const { data: subscription } = useSubscription(undefined, domain)
 
-  const { isLoading, notifications, intersectionObserverRef, nextPage, } =
+  const { isLoading, notifications, intersectionObserverRef, nextPage } =
     useNotificationsInfiniteScroll(userPubkey, domain)
 
   const ref = useRef<HTMLDivElement>(null)
@@ -64,10 +64,10 @@ const AppNotifications = () => {
   }, [domain])
 
   useEffect(() => {
-    if(notifications) {
+    if (notifications) {
       setNotificationsWrapper({
-	unreadNotifications: notifications.filter(notification => !notification.isRead),
-	notifications: notifications.filter(notification => notification.isRead)
+        unreadNotifications: notifications.filter(notification => !notification.isRead),
+        notifications: notifications.filter(notification => notification.isRead)
       })
     }
   }, [notifications])

--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -86,7 +86,7 @@ const AppNotifications = () => {
           newUnreadToAdd.push(notification)
         }
       })
-      const newUnreadNotifications = [...currentUnread, ...newUnreadToAdd]
+      const newUnreadNotifications = [...newUnreadToAdd, ...currentUnread]
       return {
         unreadNotifications: newUnreadNotifications,
         notifications:

--- a/src/components/notifications/AppNotifications/index.tsx
+++ b/src/components/notifications/AppNotifications/index.tsx
@@ -39,7 +39,7 @@ const AppNotifications = () => {
 
   const { data: subscription } = useSubscription(undefined, domain)
 
-  const { isLoading, notifications, intersectionObserverRef, nextPage } =
+  const { isLoading, notifications, intersectionObserverRef, nextPage, } =
     useNotificationsInfiniteScroll(userPubkey, domain)
 
   const ref = useRef<HTMLDivElement>(null)
@@ -64,40 +64,12 @@ const AppNotifications = () => {
   }, [domain])
 
   useEffect(() => {
-    setNotificationsWrapper(({ unreadNotifications: currentUnread }) => {
-      const newUnreadToAdd: typeof currentUnread = []
-      notifications?.forEach(notification => {
-        const wasPreviouslyUnreadInView = currentUnread.some(
-          unreadNotification => unreadNotification.id === notification.id
-        )
-
-        if (wasPreviouslyUnreadInView) {
-          if (notification.isRead) {
-            // No need to guard this in an `if` as it is guaranteed to be valid because of the above `some` check.
-            const id = currentUnread.findIndex(
-              previouslyUnreadNotification => previouslyUnreadNotification.id === notification.id
-            )
-            currentUnread[id].isRead = true
-          }
-          return
-        }
-
-        if (!notification.isRead) {
-          newUnreadToAdd.push(notification)
-        }
+    if(notifications) {
+      setNotificationsWrapper({
+	unreadNotifications: notifications.filter(notification => !notification.isRead),
+	notifications: notifications.filter(notification => notification.isRead)
       })
-      const newUnreadNotifications = [...newUnreadToAdd, ...currentUnread]
-      return {
-        unreadNotifications: newUnreadNotifications,
-        notifications:
-          notifications?.filter(
-            notification =>
-              !newUnreadNotifications.some(
-                unreadNotification => unreadNotification.id === notification.id
-              )
-          ) ?? []
-      }
-    })
+    }
   }, [notifications])
 
   const onlyUnreadNotificationsVisible =

--- a/src/components/settings/NotificationsSettings/index.tsx
+++ b/src/components/settings/NotificationsSettings/index.tsx
@@ -14,7 +14,11 @@ import SettingsContext from '@/contexts/SettingsContext/context'
 import { getFirebaseToken } from '@/utils/firebase'
 import { useNotificationPermissionState } from '@/utils/hooks/notificationHooks'
 import { getDbEchoRegistrations } from '@/utils/idb'
-import { notificationsAvailableInBrowser, requireNotifyPermission, userEnabledNotification } from '@/utils/notifications'
+import {
+  notificationsAvailableInBrowser,
+  requireNotifyPermission,
+  userEnabledNotification
+} from '@/utils/notifications'
 import { showSuccessMessageToast } from '@/utils/toasts'
 
 import SettingsHeader from '../SettingsHeader'
@@ -58,7 +62,7 @@ const NotificationsSettings: React.FC = () => {
   }, [])
 
   const handleEnableNotifications = async () => {
-    if (client && await requireNotifyPermission()) {
+    if (client && (await requireNotifyPermission())) {
       const token = await getFirebaseToken()
       if (token) {
         await client.registerWithPushServer(token)

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,4 +1,4 @@
-const MAX_FIREBASE_RETRY_COUNT = 3;
+const MAX_FIREBASE_RETRY_COUNT = 3
 
 export const getFirebaseToken = async (retryCount = 0): Promise<string | null> => {
   if (retryCount >= MAX_FIREBASE_RETRY_COUNT) {

--- a/tests/shared/pages/InboxPage.ts
+++ b/tests/shared/pages/InboxPage.ts
@@ -3,7 +3,10 @@ import { type Locator, type Page, expect } from '@playwright/test'
 export class InboxPage {
   private readonly connectButton: Locator
 
-  constructor(public readonly page: Page, private readonly baseURL: string) {
+  constructor(
+    public readonly page: Page,
+    private readonly baseURL: string
+  ) {
     this.connectButton = this.page.getByRole('button', { name: 'Connect Wallet' })
   }
 
@@ -28,14 +31,14 @@ export class InboxPage {
   async getConnectUri(): Promise<string> {
     await this.page.goto(this.baseURL)
 
-    let retryModal = 0;
-    let qrCodeVisible = false;
+    let retryModal = 0
+    let qrCodeVisible = false
 
-      const qrCode = this.page.locator('wui-qr-code')
+    const qrCode = this.page.locator('wui-qr-code')
 
-    while(retryModal < 3 && !qrCodeVisible) {
+    while (retryModal < 3 && !qrCodeVisible) {
       await this.connectButton.waitFor({
-	state: 'visible'
+        state: 'visible'
       })
 
       await this.connectButton.click()
@@ -46,16 +49,16 @@ export class InboxPage {
       })
       await connect.click()
 
-      retryModal++;
+      retryModal++
       await qrCode.waitFor({
         state: 'visible',
         timeout: 10_000
       })
 
-      qrCodeVisible = await qrCode.isVisible();
+      qrCodeVisible = await qrCode.isVisible()
 
-      if(!qrCodeVisible) {
-	this.page.getByTestId('w3m-header-close').click()
+      if (!qrCodeVisible) {
+        this.page.getByTestId('w3m-header-close').click()
       }
     }
 

--- a/tests/shared/pages/SettingsPage.ts
+++ b/tests/shared/pages/SettingsPage.ts
@@ -1,7 +1,10 @@
 import { type Locator, type Page, expect } from '@playwright/test'
 
 export class SettingsPage {
-  constructor(public readonly page: Page, private readonly baseURL: string) {}
+  constructor(
+    public readonly page: Page,
+    private readonly baseURL: string
+  ) {}
 
   async load() {}
 

--- a/tests/shared/pages/WalletPage.ts
+++ b/tests/shared/pages/WalletPage.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import { expect, type Locator, type Page } from '@playwright/test'
+import { type Locator, type Page, expect } from '@playwright/test'
 
 import { WALLET_URL } from '../constants'
 import type { SessionParams } from '../types'

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -132,7 +132,7 @@ test('it should subscribe, receive messages and unsubscribe', async ({
     projectSecret: CUSTOM_TEST_DAPP.projectSecret
   }
 
-  const test1Body = `${messageSearchToken} Test Body`
+  const test1Body = `${messageSearchToken} Test1 Body`
   await notifyServer.sendMessage({
     body: test1Body,
     title: 'Test1 Title',
@@ -157,6 +157,6 @@ test('it should subscribe, receive messages and unsubscribe', async ({
   const allMessages = await inboxPage.page.getByText(messageSearchToken, { exact: false }).all()
 
   // Ensure messages are ordered correctly.
-  expect(allMessages[0].innerHTML).toEqual(test2Body)
-  expect(allMessages[1].innerHTML).toEqual(test1Body)
+  expect(await allMessages[0].innerHTML()).toEqual(test2Body)
+  expect(await allMessages[1].innerHTML()).toEqual(test1Body)
 })

--- a/tests/subscribe.spec.ts
+++ b/tests/subscribe.spec.ts
@@ -8,7 +8,8 @@ test.beforeEach(async ({ inboxPage, walletPage, browserName }) => {
   }
   const uri = await inboxPage.getConnectUri()
   await walletPage.connectWithUri(uri)
-  await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)})
+  await walletPage.handleSessionProposal(DEFAULT_SESSION_PARAMS)
+})
 
 test.afterEach(async ({ inboxPage, inboxValidator, walletValidator }) => {
   await inboxPage.disconnect()
@@ -118,20 +119,44 @@ test('it should subscribe, receive messages and unsubscribe', async ({
 
   await inboxPage.subscribeAndNavigateToDapp(CUSTOM_TEST_DAPP.name)
 
-  const address = await inboxPage.getAddress()
+  // use fixed token to search for messages in a "human" way
+  const messageSearchToken = 'MESSAGE_QUERY'
 
-  await notifyServer.sendMessage({
+  const address = await inboxPage.getAddress()
+  const baseMessageParams = {
     accounts: [`eip155:1:${address}`],
-    body: 'Test Body',
-    title: 'Test Title',
     type: CUSTOM_TEST_DAPP.notificationType,
     url: CUSTOM_TEST_DAPP.appDomain,
     icon: CUSTOM_TEST_DAPP.icons[0],
     projectId: CUSTOM_TEST_DAPP.projectId,
     projectSecret: CUSTOM_TEST_DAPP.projectSecret
+  }
+
+  const test1Body = `${messageSearchToken} Test Body`
+  await notifyServer.sendMessage({
+    body: test1Body,
+    title: 'Test1 Title',
+    ...baseMessageParams
   })
 
-  await inboxPage.page.getByText('Test Body').waitFor({ state: 'visible' })
+  await inboxPage.page.getByText(test1Body).waitFor({ state: 'visible' })
 
-  expect(await inboxPage.page.getByText('Test Body').isVisible()).toEqual(true)
+  expect(await inboxPage.page.getByText(test1Body).isVisible()).toEqual(true)
+
+  const test2Body = `${messageSearchToken} Test2 Body`
+  await notifyServer.sendMessage({
+    body: test2Body,
+    title: 'Test2 Title',
+    ...baseMessageParams
+  })
+
+  await inboxPage.page.getByText(test2Body).waitFor({ state: 'visible' })
+
+  expect(await inboxPage.page.getByText(test2Body).isVisible()).toEqual(true)
+
+  const allMessages = await inboxPage.page.getByText(messageSearchToken, { exact: false }).all()
+
+  // Ensure messages are ordered correctly.
+  expect(allMessages[0].innerHTML).toEqual(test2Body)
+  expect(allMessages[1].innerHTML).toEqual(test1Body)
 })


### PR DESCRIPTION
# Description

- Fixes bug where new notifications are at the bottom of the list.
- Simplify logic for ordering notifications
- Add check for message ordering in e2e tests
- run prettier

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Draft PR (breaking/non-breaking change which needs more work for having a proper functionality _[Mark this PR as ready to review only when completely ready]_)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
