### PR TITLE
feat: change canary ECR repo

### DIFF
--- a/.github/workflows/publish_canary.yml
+++ b/.github/workflows/publish_canary.yml
@@ -16,8 +16,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ECR_DEPLOYER }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ECR_PUBLISHER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_ECR_PUBLISHER_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
We are moving canaries into a different AWS account.

@devceline can you please add the following secrets to this repo
https://start.1password.com/open/i?a=BMHDRH3RNBEU3EH5L3SMXGKJTA&v=t4ntljt7ggo2tdyspp44reqlbm&i=rh5e5gtanozfc2jj7elo5tyz7y&h=team-reown.1password.com

`AWS_ECR_PUBLISHER_ACCESS_KEY_ID: $username`
`AWS_ECR_PUBLISHER_SECRET_ACCESS_KEY: $password`

The old one can be removed if it's not being used for anything else (doesn't seem like it)
